### PR TITLE
Fix navigation block

### DIFF
--- a/www/js/blocks.js
+++ b/www/js/blocks.js
@@ -361,7 +361,7 @@ export class BLOCK {
             (c[0] + 0.5) / tx_cnt,
             (c[1] + 0.5) / tx_cnt,
             1 / tx_cnt,
-            1 / tx_cnt,
+            c[2] === 2 ? - 1 / tx_cnt : 1 / tx_cnt
         ];
     }
 

--- a/www/resource_packs/default/blocks.json
+++ b/www/resource_packs/default/blocks.json
@@ -2862,8 +2862,9 @@
         "name": "TEST",
         "inventory_icon_id": 445,
         "sound": "madcraft:block.wood",
+        "uvlock": false,
         "texture": {
-            "up": [26, 31],
+            "up": [26, 31, 2],
             "down": [27, 31],
             "south": [28, 31],
             "east": [29, 31],


### PR DESCRIPTION
temp fix
Rotate nav block top 180 degrees, special instruction for texture regions.

`[8, 9. 2]` means "take tile at (8,9) and rotate by 2"