### PR TITLE
Fix cave light

### DIFF
--- a/www/js/light_worker.js
+++ b/www/js/light_worker.js
@@ -577,9 +577,12 @@ class Chunk {
         // default value for daylight
         const defLight = world.defDayLight;
         if (defLight > 0) {
-            for (let coord = outerLen - 2 * sy; coord < outerLen; coord++) {
-                uint8View[coord * strideBytes + OFFSET_DAY + OFFSET_SOURCE] = defLight;
-            }
+            for (let y = aabb.y_max - 1; y < aabb.y_max + 1; y++)
+                for (let z = aabb.z_min; z < aabb.z_max; z++)
+                    for (let x = aabb.x_min; x < aabb.x_max; x++) {
+                        const coord = x * sx + y * sy + z * sz + shiftCoord;
+                        uint8View[coord * strideBytes + OFFSET_DAY + OFFSET_SOURCE] = defLight;
+                    }
         }
 
         for (let portal of portals) {
@@ -625,7 +628,9 @@ class Chunk {
                         const dayLight = bytes2[coord2 + OFFSET_DAY + OFFSET_LIGHT];
                         const dayLightSrc = bytes2[coord2 + OFFSET_DAY + OFFSET_SOURCE];
                         uint8View[coord1 + OFFSET_DAY + OFFSET_LIGHT] = dayLight;
-                        uint8View[coord1 + OFFSET_DAY + OFFSET_SOURCE] = dayLightSrc;
+                        if (f2 || dayLightSrc > 0) {
+                            uint8View[coord1 + OFFSET_DAY + OFFSET_SOURCE] = dayLightSrc;
+                        }
                         if (f2 && dayLightSrc !== defLight) {
                             foundDay = true;
                         }

--- a/www/js/light_worker.js
+++ b/www/js/light_worker.js
@@ -45,7 +45,8 @@ const dy = [0, 0, 1, -1, 0, 0, /*|*/ 1, 1, -1, -1, 0, 0, 0, 0, 1, 1, -1, -1, /*|
 const dz = [0, 0, 0, 0, 1, -1, /*|*/ 0, 0, 0, 0, 1, 1, -1, -1, 1, -1, 1, -1, /*|*/ 1, 1, 1, 1, -1, -1, -1, -1];
 const dlen = [];
 const dmask = [];
-const DIR_COUNT = 26;
+const DIR_COUNT = 6; //26 // 26 is full 3d light approx
+const DIR_MAX_MASK = (1<<26) - (1<<6);
 
 function adjustSrc(srcLight) {
     srcLight = srcLight & MASK_BLOCK;
@@ -169,6 +170,9 @@ class LightQueue {
                 }
                 for (let d = 0; d < DIR_COUNT; d++) {
                     if ((mask & (1 << d)) !== 0) {
+                        // if (d >= 6 && mask >= DIR_MAX_MASK) {
+                        //     break;
+                        // }
                         continue;
                     }
                     let coord2 = coord + dif26[d];


### PR DESCRIPTION
Remove all out-of-bounds temp lights, process neighbours in fillOuter() instead - that fixes strange cave lights

set `DIR_COUNT=6` because diagonals are too slow in current configuration. 