### PR TITLE
pack colors into IndexedColor

### DIFF
--- a/node_server/texture-pack-compiler/compile.json
+++ b/node_server/texture-pack-compiler/compile.json
@@ -46,7 +46,7 @@
             "compile": {
                 "overlay_mask": "./textures/water_overlay.png"
             },
-            "mask_color": {"r": 0.8105, "g": 0.615, "b": 0},
+            "mask_color": {"r": 830, "g": 630, "b": 0},
             "spawnable": false
         },
         {
@@ -71,7 +71,7 @@
             "tags": [
                 "mask_color"
             ],
-            "mask_color": {"r": 0.8105, "g": 0.615, "b": 0},
+            "mask_color": {"r": 830, "g": 630, "b": 0},
             "fluid": {
                 "max_power": 1,
                 "still_block_id": 202
@@ -2633,7 +2633,7 @@
             "material": {
                 "id": "stone"
             },
-            "redstone": {}, 
+            "redstone": {},
             "texture": {
                 "up": "block/tnt_top.png",
                 "down": "block/tnt_bottom.png",

--- a/node_server/texture-pack-compiler/compile_data.js
+++ b/node_server/texture-pack-compiler/compile_data.js
@@ -85,7 +85,7 @@ export class CompileData {
         for(let color in COLOR_PALETTE) {
             const color_pos = COLOR_PALETTE[color];
             const mask_color = new Color(color_pos[0], color_pos[1], 0, 0);
-            const TX_CNT = 32;
+            const TX_CNT = 32 / 1024.0;
             mask_color.r = (palette_pos.x + 0.25 * mask_color.r + 0.125) / TX_CNT;
             mask_color.g = (palette_pos.y + 0.25 * mask_color.g + 0.125) / TX_CNT;
             const b = {
@@ -150,7 +150,7 @@ export class CompileData {
         for(let color in COLOR_PALETTE) {
             const color_pos = COLOR_PALETTE[color];
             const mask_color = new Color(color_pos[0], color_pos[1], 0, 1);
-            const TX_CNT = 32;
+            const TX_CNT = 32 / 1024.0;
             mask_color.r = (palette_pos.x + 0.25 * mask_color.r + 0.125) / TX_CNT;
             mask_color.g = (palette_pos.y + 0.25 * mask_color.g + 0.125) / TX_CNT;
             const b = {
@@ -190,7 +190,7 @@ export class CompileData {
         for(let color in COLOR_PALETTE) {
             const color_pos = COLOR_PALETTE[color];
             const mask_color = new Color(color_pos[0], color_pos[1], 0, 1);
-            const TX_CNT = 32;
+            const TX_CNT = 32 / 1024.0;
             mask_color.r = (palette_pos.x + 0.25 * mask_color.r + 0.125) / TX_CNT;
             mask_color.g = (palette_pos.y + 0.25 * mask_color.g + 0.125) / TX_CNT;
             const b = {
@@ -227,7 +227,7 @@ export class CompileData {
         for(let color in COLOR_PALETTE) {
             const color_pos = COLOR_PALETTE[color];
             const mask_color = new Color(color_pos[0], color_pos[1], 0);
-            const TX_CNT = 32;
+            const TX_CNT = 32 / 1024.0;
             mask_color.r = (palette_pos.x + 0.25 * mask_color.r + 0.125) / TX_CNT;
             mask_color.g = (palette_pos.y + 0.25 * mask_color.g + 0.125) / TX_CNT;
             const b = {
@@ -432,7 +432,7 @@ export class CompileData {
         for(let color in COLOR_PALETTE) {
             const color_pos = COLOR_PALETTE[color];
             const mask_color = new Color(color_pos[0], color_pos[1], 0, 1);
-            const TX_CNT = 32;
+            const TX_CNT = 32 / 1024.0;
             mask_color.r = (palette_pos.x + 0.25 * mask_color.r + 0.125) / TX_CNT;
             mask_color.g = (palette_pos.y + 0.25 * mask_color.g + 0.125) / TX_CNT;
             const b = {
@@ -455,7 +455,7 @@ export class CompileData {
         for(let color in COLOR_PALETTE) {
             const color_pos = COLOR_PALETTE[color];
             const mask_color = new Color(color_pos[0], color_pos[1], 0, 1);
-            const TX_CNT = 32;
+            const TX_CNT = 32 / 1024.0;
             mask_color.r = (palette_pos.x + 0.25 * mask_color.r + 0.125) / TX_CNT;
             mask_color.g = (palette_pos.y + 0.25 * mask_color.g + 0.125) / TX_CNT;
             const b = {
@@ -480,7 +480,7 @@ export class CompileData {
         for(let color in COLOR_PALETTE) {
             const color_pos = COLOR_PALETTE[color];
             const mask_color = new Color(color_pos[0], color_pos[1], 0, 1);
-            const TX_CNT = 32;
+            const TX_CNT = 32 / 1024.0;
             mask_color.r = (palette_pos.x + 0.25 * mask_color.r + 0.125) / TX_CNT;
             mask_color.g = (palette_pos.y + 0.25 * mask_color.g + 0.125) / TX_CNT;
             const b = {
@@ -501,7 +501,7 @@ export class CompileData {
         for(let color in COLOR_PALETTE) {
             const color_pos = COLOR_PALETTE[color];
             const mask_color = new Color(color_pos[0], color_pos[1], 0, 1);
-            const TX_CNT = 32;
+            const TX_CNT = 32 / 1024.0;
             mask_color.r = (palette_pos.x + 0.25 * mask_color.r + 0.125) / TX_CNT;
             mask_color.g = (palette_pos.y + 0.25 * mask_color.g + 0.125) / TX_CNT;
             const b = {
@@ -523,7 +523,7 @@ export class CompileData {
         for(let color in COLOR_PALETTE) {
             const color_pos = COLOR_PALETTE[color];
             const mask_color = new Color(color_pos[0], color_pos[1], 0, 1);
-            const TX_CNT = 32;
+            const TX_CNT = 32 / 1024.0;
             mask_color.r = (palette_pos.x + 0.25 * mask_color.r + 0.125) / TX_CNT;
             mask_color.g = (palette_pos.y + 0.25 * mask_color.g + 0.125) / TX_CNT;
             const b = {
@@ -633,10 +633,10 @@ export class CompileData {
     initBanner() {
         const palette_pos = {x: 24, y: 31};
         let i = 0;
-        const TX_CNT = 32;
+        const TX_CNT = 32 / 1024.0;
         for(let color in COLOR_PALETTE) {
             const color_pos = COLOR_PALETTE[color];
-            const mask_color = new Color(color_pos[0], color_pos[1], 4/32, 0);
+            const mask_color = new Color(color_pos[0], color_pos[1], 4, 0);
             mask_color.r = (palette_pos.x + 0.25 * mask_color.r + 0.125) / TX_CNT;
             mask_color.g = (palette_pos.y + 0.25 * mask_color.g + 0.125) / TX_CNT;
             const b = {

--- a/www/js/base_resource_pack.js
+++ b/www/js/base_resource_pack.js
@@ -172,8 +172,8 @@ export class BaseResourcePack {
 
         textureInfo.imageData = ctx.getImageData(0, 0, image.width, image.height);
         textureInfo.getColorAt = function(x, y) {
-            const ax = (x * this.width) | 0;
-            const ay = (y * this.height) | 0;
+            const ax = (x * this.width / 1024.0) | 0;
+            const ay = (y * this.height / 1024.0) | 0;
             const index = ((ay * this.width) + ax) * 4;
             return new Color(
                 this.imageData.data[index + 0],
@@ -302,7 +302,9 @@ export class BaseResourcePack {
         const resp = module.func(block, vertices, world, pos.x, pos.y, pos.z, neighbours, biome, dirt_color, true, _matrix, _pivot, force_tex);
         // stat.count++;
         // stat.time += (performance.now() - p);
-
+        if (vertices.length % 15 > 0) {
+            console.log("oops mesh");
+        }
         return resp;
     }
 

--- a/www/js/bedrockJsonParser.js
+++ b/www/js/bedrockJsonParser.js
@@ -40,7 +40,7 @@ const computePivot = vec3.create();
 const computeScale = vec3.create();
 const computeRot = quat.create();
 
-const lm = {r : -1, g : -1, b : -1};
+const lm = 0;
 
 /**
  * Fill cube from bedrock cube notation.
@@ -138,7 +138,7 @@ export function fillCube({
             xX, xZ, xY,
             zX, zZ, zY,
             c[0], c[1], c[2] * flip, -c[3],
-            lm.r, lm.g, lm.b, flags);
+            lm, flags);
 
         //down
         c = uv.down;
@@ -146,7 +146,7 @@ export function fillCube({
             xX, xZ, xY,
             -zX, -zZ, -zY,
             c[0], c[1], c[2] * flip, -c[3],
-            lm.r, lm.g, lm.b, flags);
+            lm, flags);
 
     }
 
@@ -157,7 +157,7 @@ export function fillCube({
             xX, xZ, xY,
             yX, yZ, yY,
             c[0], c[1], c[2] * flip, -c[3],
-            lm.r, lm.g, lm.b, flags);
+            lm, flags);
 
         //south
         c = uv.south;
@@ -165,7 +165,7 @@ export function fillCube({
             xX, xZ, xY,
             -yX, -yZ, -yY,
             c[0], c[1], -c[2] * flip, c[3],
-            lm.r, lm.g, lm.b, flags);
+            lm, flags);
     }
 
     if (dy * dz > 0) {
@@ -175,7 +175,7 @@ export function fillCube({
             zX, zZ, zY,
             -yX, -yZ, -yY,
             c[0], c[1], -c[2] * flip, c[3],
-            lm.r, lm.g, lm.b, flags);
+            lm, flags);
 
         //east
         c = mirror ? uv.west : uv.east;
@@ -183,7 +183,7 @@ export function fillCube({
             zX, zZ, zY,
             yX, yZ, yY,
             c[0], c[1], c[2] * flip, -c[3],
-            lm.r, lm.g, lm.b, flags);
+            lm, flags);
     }
 
     return target;

--- a/www/js/block_style/bed.js
+++ b/www/js/block_style/bed.js
@@ -1,4 +1,4 @@
-import {Color, DIRECTION, QUAD_FLAGS, Vector} from '../helpers.js';
+import {IndexedColor, DIRECTION, QUAD_FLAGS, Vector} from '../helpers.js';
 import {BLOCK} from "../blocks.js";
 import {CHUNK_SIZE_X, CHUNK_SIZE_Z} from "../chunk_const.js";
 import {impl as alea} from "../../vendors/alea.js";
@@ -78,8 +78,8 @@ export default class style {
 
         // flags
         const flags = QUAD_FLAGS.MASK_BIOME;
-        const lm = new Color(block.material.mask_color.r, block.material.mask_color.g, 0, 0);
-        const mask_shift = lm.b = 4/32; // offset for mask
+        const lm = new IndexedColor(block.material.mask_color.r, block.material.mask_color.g, 0, 0);
+        const mask_shift = lm.b = 4; // offset for mask
 
         // textures
         const c_head = BLOCK.calcMaterialTexture(block.material, DIRECTION.SOUTH);

--- a/www/js/block_style/candle.js
+++ b/www/js/block_style/candle.js
@@ -1,4 +1,4 @@
-import {DIRECTION, QUAD_FLAGS, MULTIPLY, Vector} from '../helpers.js';
+import {DIRECTION, QUAD_FLAGS, IndexedColor, Vector} from '../helpers.js';
 import {BLOCK} from "../blocks.js";
 import {AABB} from '../core/AABB.js';
 import { default as default_style, TX_SIZE } from './default.js';
@@ -9,7 +9,7 @@ const HEIGHT = 6 / TX_SIZE;
 
 const {mat4} = glMatrix;
 
-const lm = MULTIPLY.COLOR.WHITE.clone();
+const lm = IndexedColor.WHITE.clone();
 
 // Свечи
 export default class style {

--- a/www/js/block_style/cocoa.js
+++ b/www/js/block_style/cocoa.js
@@ -1,4 +1,4 @@
-import {DIRECTION, QUAD_FLAGS, MULTIPLY, Vector} from '../helpers.js';
+import {DIRECTION, QUAD_FLAGS, IndexedColor, Vector} from '../helpers.js';
 import {BLOCK} from "../blocks.js";
 import {AABB} from '../core/AABB.js';
 import { default as default_style } from './default.js';
@@ -10,7 +10,7 @@ const HEIGHT = 20 / 32;
 
 const {mat4} = glMatrix;
 
-const lm = MULTIPLY.COLOR.WHITE.clone();
+const lm = IndexedColor.WHITE.clone();
 
 // Фонарь
 export default class style {

--- a/www/js/block_style/cube.js
+++ b/www/js/block_style/cube.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import {DIRECTION, MULTIPLY, QUAD_FLAGS, Vector, calcRotateMatrix} from '../helpers.js';
+import {DIRECTION, IndexedColor, QUAD_FLAGS, Vector, calcRotateMatrix} from '../helpers.js';
 import {impl as alea} from "../../vendors/alea.js";
 import {BLOCK} from "../blocks.js";
 import {CHUNK_SIZE_X, CHUNK_SIZE_Y, CHUNK_SIZE_Z} from "../chunk_const.js";
@@ -132,9 +132,9 @@ export default class style {
         let flags = 0;
 
         // Texture color multiplier
-        let lm = MULTIPLY.COLOR.WHITE;
+        let lm = IndexedColor.WHITE;
         if(material.tags.indexOf('mask_biome') >= 0) {
-            lm = dirt_color || MULTIPLY.COLOR.GRASS;
+            lm = dirt_color || IndexedColor.GRASS;
             flags = QUAD_FLAGS.MASK_BIOME;
         } else if(material.tags.indexOf('mask_color') >= 0) {
             flags = QUAD_FLAGS.MASK_BIOME;
@@ -233,7 +233,7 @@ export default class style {
         let depth                   = 1;
         let autoUV                  = true;
         let axes_up                 = null;
-        let lm                      = MULTIPLY.COLOR.WHITE;
+        let lm                      = IndexedColor.WHITE;
         let flags                   = material.light_power ? QUAD_FLAGS.NO_AO : 0;
         let sideFlags               = flags;
         let upFlags                 = flags;
@@ -308,7 +308,7 @@ export default class style {
 
             // Texture color multiplier
             if(block.hasTag('mask_biome')) {
-                lm = dirt_color; // MULTIPLY.COLOR.GRASS;
+                lm = dirt_color; // IndexedColor.GRASS;
                 sideFlags = QUAD_FLAGS.MASK_BIOME;
                 upFlags = QUAD_FLAGS.MASK_BIOME;
             }

--- a/www/js/block_style/door.js
+++ b/www/js/block_style/door.js
@@ -1,4 +1,4 @@
-import {DIRECTION, MULTIPLY, ROTATE, TX_CNT, Vector} from '../helpers.js';
+import {DIRECTION, IndexedColor, ROTATE, TX_CNT, Vector} from '../helpers.js';
 import {CubeSym, pushSym} from '../core/CubeSym.js';
 import {BLOCK} from "../blocks.js";
 
@@ -111,7 +111,7 @@ export default class style {
 //
 function push_part(vertices, cardinal_direction, cx, cy, cz, x, y, z, xs, zs, ys, tex_up_down, tex_front, tex_side, opened, left) {
 
-    let lm              = MULTIPLY.COLOR.WHITE; // Texture color multiplier
+    let pp              = IndexedColor.WHITE.packed; // Texture color multiplier
     let flags           = 0;
     let sideFlags       = 0;
     let upFlags         = 0;
@@ -133,41 +133,41 @@ function push_part(vertices, cardinal_direction, cx, cy, cz, x, y, z, xs, zs, ys
         x, z, y + ys,
         ...top_rotate,
         tex_up_down[0], tex_up_down[1], orient * tex_up_down[2], tex_up_down[3],
-        lm.r, lm.g, lm.b, flags | upFlags);
+        pp, flags | upFlags);
     // BOTTOM
     pushSym(vertices, cardinal_direction,
         cx, cz, cy,
         x, z, y + Z_FIGHT_ERROR,
         ...bottom_rotate,
         tex_up_down[0], tex_up_down[1], orient * tex_up_down[2], tex_up_down[3],
-        lm.r, lm.g, lm.b, flags);
+        pp, flags);
     // SOUTH
     pushSym(vertices, cardinal_direction,
         cx, cz, cy,
         x, z - zs/2, y + ys/2,
         ...south_rotate,
         tex_front[0], tex_front[1], orient * tex_front[2], -tex_front[3],
-        lm.r, lm.g, lm.b, flags | sideFlags);
+        pp, flags | sideFlags);
     // NORTH
     pushSym(vertices, cardinal_direction,
         cx, cz, cy,
         x, z + zs/2, y + ys/2,
         ...north_rotate,
         tex_front[0], tex_front[1], orient * tex_front[2], tex_front[3],
-        lm.r, lm.g, lm.b, flags | sideFlags);
+        pp, flags | sideFlags);
     // WEST
     pushSym(vertices, cardinal_direction,
         cx, cz, cy,
         x - xs/2 * (1 - Z_FIGHT_ERROR), z, y + ys/2,
         ...west_rotate,
         tex_side[0], tex_side[1], orient * tex_side[2], -tex_side[3],
-        lm.r, lm.g, lm.b, flags | sideFlags);
+        pp, flags | sideFlags);
     // EAST
     pushSym(vertices, cardinal_direction,
         cx, cz, cy,
         x + xs/2 * (1 - Z_FIGHT_ERROR), z, y + ys/2,
         ...east_rotate,
         tex_side[0], tex_side[1], orient * tex_side[2], -tex_side[3],
-        lm.r, lm.g, lm.b, flags | sideFlags);
+        pp, flags | sideFlags);
 
 }

--- a/www/js/block_style/extruder.js
+++ b/www/js/block_style/extruder.js
@@ -1,4 +1,4 @@
-import {MULTIPLY, DIRECTION, Color, Vector, QUAD_FLAGS} from '../helpers.js';
+import {IndexedColor, DIRECTION, Color, Vector, QUAD_FLAGS} from '../helpers.js';
 import {BLOCK} from "../blocks.js";
 
 const {mat3, mat4} = glMatrix;
@@ -14,8 +14,7 @@ export function pushTransformed(
     ux, uz, uy,
     vx, vz, vy,
     c0, c1, c2, c3,
-    r, g, b,
-    flags
+    pp, flags
 ) {
     pivot = pivot || defaultPivot;
     cx += pivot[0];
@@ -55,7 +54,7 @@ export function pushTransformed(
         vx * mat[6] + vy * mat[7] + vz * mat[8],
         vx * mat[3] + vy * mat[4] + vz * mat[5],
 
-        c0, c1, c2, c3, r, g, b, flags
+        c0, c1, c2, c3, pp, flags
     );
 }
 
@@ -174,7 +173,7 @@ export default class style {
             0,
         ];
 
-        let lm = MULTIPLY.COLOR.WHITE;
+        let lm = IndexedColor.WHITE;
         let z = -0.5 - 0.5 / SCALE_FACTOR;
         let flags = QUAD_FLAGS.NO_AO;
 
@@ -185,6 +184,7 @@ export default class style {
             lm = material.mask_color;
             flags = QUAD_FLAGS.MASK_BIOME;
         }
+        let pp = IndexedColor.packLm(lm);
 
         let height = 1.0;
         let width = 1.0;
@@ -194,14 +194,14 @@ export default class style {
             MUL, 0, 0,
             0, 0, MUL * height,
             c[0], c[1], c[2], -c[3],
-            lm.r, lm.g, lm.b, flags);
+            pp, flags);
 
         vertices.push(
             _x, scale.z * (MUL*0.75) + _z, _y,
             MUL, 0, 0,
             0, 0, -MUL * height,
             c[0], c[1], c[2], c[3],
-            lm.r, lm.g, lm.b, flags);
+            pp, flags);
 
         let uc = 1 / tex.width;
         let vc = 1 / tex.height;
@@ -233,7 +233,7 @@ export default class style {
                         1, 0, 0,
                         0, MUL, 0,
                         u, v, uc, vc,
-                        lm.r, lm.g, lm.b, flags
+                        pp, flags
                     );
                 }
 
@@ -246,7 +246,7 @@ export default class style {
                         1, 0, 0,
                         0, -1 * MUL, 0,
                         u, v, uc, vc,
-                        lm.r, lm.g, lm.b, flags);
+                        pp, flags);
                 }
 
                 // West
@@ -258,7 +258,7 @@ export default class style {
                         0, 1 * MUL, 0,
                         0, 0, -height,
                         u, v, uc, vc,
-                        lm.r, lm.g, lm.b, flags);
+                        pp, flags);
                 }
 
                 // East
@@ -270,7 +270,7 @@ export default class style {
                         0, 1 * MUL, 0,
                         0, 0, height,
                         u, v, uc, vc,
-                        lm.r, lm.g, lm.b, flags);
+                        pp, flags);
                 }
             }
         }

--- a/www/js/block_style/fence.js
+++ b/www/js/block_style/fence.js
@@ -1,4 +1,4 @@
-import {DIRECTION, MULTIPLY, ROTATE} from '../helpers.js';
+import {DIRECTION, IndexedColor, ROTATE} from '../helpers.js';
 import {BLOCK, NEIGHB_BY_SYM} from "../blocks.js";
 
 // Забор
@@ -18,12 +18,6 @@ export default class style {
         }
 
         const cardinal_direction = block.getCardinalDirection();
-
-        // Texture color multiplier
-        let lm = MULTIPLY.COLOR.WHITE;
-        if(block.id == BLOCK.GRASS_BLOCK.id) {
-            lm = dirt_color; // MULTIPLY.COLOR.GRASS;
-        }
 
         let DIRECTION_BACK          = DIRECTION.BACK;
         let DIRECTION_RIGHT         = DIRECTION.RIGHT;
@@ -108,7 +102,7 @@ export default class style {
 }
 
 function push_part(vertices, c, x, y, z, xs, zs, h) {
-    let lm          = MULTIPLY.COLOR.WHITE;
+    let pp          = IndexedColor.WHITE.packed;
     let flags       = 0;
     let sideFlags   = 0;
     let upFlags     = 0;
@@ -117,35 +111,35 @@ function push_part(vertices, c, x, y, z, xs, zs, h) {
         xs, 0, 0,
         0, zs, 0,
         c[0], c[1], c[2] * xs, c[3] * zs,
-        lm.r, lm.g, lm.b, flags | upFlags);
+        pp, flags | upFlags);
     // BOTTOM
     vertices.push(x, z, y,
         xs, 0, 0,
         0, -zs, 0,
         c[0], c[1], c[2] * xs, c[3] * zs,
-        lm.r, lm.g, lm.b, flags);
+        pp, flags);
     // SOUTH
     vertices.push(x, z - zs/2, y + h/2,
         xs, 0, 0,
         0, 0, h,
         c[0], c[1], c[2]*xs, -c[3]*h,
-        lm.r, lm.g, lm.b, flags | sideFlags);
+        pp, flags | sideFlags);
     // NORTH
     vertices.push(x, z + zs/2, y + h/2,
         xs, 0, 0,
         0, 0, -h,
         c[0], c[1], -c[2]*xs, c[3]*h,
-        lm.r, lm.g, lm.b, flags | sideFlags);
+        pp, flags | sideFlags);
     // WEST
     vertices.push(x - xs/2, z, y + h/2,
         0, zs, 0,
         0, 0, -h,
         c[0], c[1], -c[2]*zs, c[3]*h,
-        lm.r, lm.g, lm.b, flags | sideFlags);
+        pp, flags | sideFlags);
     // EAST
     vertices.push(x + xs/2, z, y + h/2,
         0, zs, 0,
         0, 0, h,
         c[0], c[1], c[2]*zs, -c[3]*h,
-        lm.r, lm.g, lm.b, flags | sideFlags);
+        pp, flags | sideFlags);
 }

--- a/www/js/block_style/fence_gate.js
+++ b/www/js/block_style/fence_gate.js
@@ -1,4 +1,4 @@
-import {DIRECTION, MULTIPLY, Vector} from '../helpers.js';
+import {DIRECTION, IndexedColor} from '../helpers.js';
 import {BLOCK} from "../blocks.js";
 import {AABB} from '../core/AABB.js';
 
@@ -14,7 +14,7 @@ export default class style {
             aabb: this.computeAABB
         };
     }
-    
+
     // computeAABB
     static computeAABB(block, for_physic) {
         let aabb = new AABB();
@@ -43,11 +43,11 @@ export default class style {
         if(!block || typeof block == 'undefined' || block.id == BLOCK.AIR.id) {
             return;
         }
-        
+
         const texture = BLOCK.calcTexture(block.material.texture, DIRECTION.FORWARD);
 
         const cardinal_direction = block.getCardinalDirection();
-        
+
         if (cardinal_direction == DIRECTION.WEST || cardinal_direction == DIRECTION.EAST) {
             // Столбы
             push_part(vertices, texture, x + 8 * SIZE, y + 4 * SIZE, z + SIZE, 2 * SIZE, 2 * SIZE, 12 * SIZE);
@@ -118,7 +118,7 @@ function push_half_gate(orientation, x, y, z, vertices, tex) {
 }
 
 function push_part(vertices, c, x, y, z, xs, zs, h) {
-    let lm          = MULTIPLY.COLOR.WHITE;
+    let pp          = IndexedColor.WHITE.packed;
     let flags       = 0;
     let sideFlags   = 0;
     let upFlags     = 0;
@@ -127,35 +127,35 @@ function push_part(vertices, c, x, y, z, xs, zs, h) {
         xs, 0, 0,
         0, zs, 0,
         c[0], c[1], c[2] * xs, c[3] * zs,
-        lm.r, lm.g, lm.b, flags | upFlags);
+        pp, flags | upFlags);
     // BOTTOM
     vertices.push(x, z, y,
         xs, 0, 0,
         0, -zs, 0,
         c[0], c[1], c[2] * xs, c[3] * zs,
-        lm.r, lm.g, lm.b, flags);
+        pp, flags);
     // SOUTH
     vertices.push(x, z - zs/2, y + h/2,
         xs, 0, 0,
         0, 0, h,
         c[0], c[1], c[2]*xs, -c[3]*h,
-        lm.r, lm.g, lm.b, flags | sideFlags);
+        pp, flags | sideFlags);
     // NORTH
     vertices.push(x, z + zs/2, y + h/2,
         xs, 0, 0,
         0, 0, -h,
         c[0], c[1], -c[2]*xs, c[3]*h,
-        lm.r, lm.g, lm.b, flags | sideFlags);
+        pp, flags | sideFlags);
     // WEST
     vertices.push(x - xs/2, z, y + h/2,
         0, zs, 0,
         0, 0, -h,
         c[0], c[1], -c[2]*zs, c[3]*h,
-        lm.r, lm.g, lm.b, flags | sideFlags);
+        pp, flags | sideFlags);
     // EAST
     vertices.push(x + xs/2, z, y + h/2,
         0, zs, 0,
         0, 0, h,
         c[0], c[1], c[2]*zs, -c[3]*h,
-        lm.r, lm.g, lm.b, flags | sideFlags);
+        pp, flags | sideFlags);
 }

--- a/www/js/block_style/ladder.js
+++ b/www/js/block_style/ladder.js
@@ -1,6 +1,6 @@
-import {MULTIPLY, ROTATE, DIRECTION, QUAD_FLAGS} from '../helpers.js';
+import {DIRECTION, IndexedColor, QUAD_FLAGS} from '../helpers.js';
 import {pushSym} from '../core/CubeSym.js';
-import {BLOCK, NEIGHB_BY_SYM} from "../blocks.js";
+import {BLOCK} from "../blocks.js";
 
 // Лестница
 export default class style {
@@ -23,7 +23,7 @@ export default class style {
         let texture     = block.material.texture;
         let bH          = 1.0;
         let width       = block.material.width ? block.material.width : 1;
-        let lm          = MULTIPLY.COLOR.WHITE;
+        let lm          = IndexedColor.WHITE;
         let c           = null;
         let flags       = 0;
 
@@ -35,6 +35,7 @@ export default class style {
         } else {
             c = BLOCK.calcTexture(texture, DIRECTION.BACK);
         }
+        let pp = IndexedColor.packLm(lm);
 
         pushSym(vertices, cardinal_direction,
             x + .5, z + .5, y + .5,
@@ -42,8 +43,7 @@ export default class style {
             1, 0, 0,
             0, 0, -bH,
             c[0], c[1], -c[2], c[3],
-            lm.r, lm.g, lm.b,
-            flags);
+            pp, flags);
     }
 
 }

--- a/www/js/block_style/lantern.js
+++ b/www/js/block_style/lantern.js
@@ -1,4 +1,4 @@
-import {DIRECTION, QUAD_FLAGS, MULTIPLY, Vector} from '../helpers.js';
+import {DIRECTION, QUAD_FLAGS, IndexedColor, Vector} from '../helpers.js';
 import {BLOCK} from "../blocks.js";
 import {AABB} from '../core/AABB.js';
 import { default as default_style } from './default.js';
@@ -11,7 +11,7 @@ const HEIGHT_INNER = 4/32;
 
 const CONNECT_HEIGHT_ON_CEIL = 6 / 16;
 
-const lm = MULTIPLY.COLOR.WHITE.clone();
+const lm = IndexedColor.WHITE.clone();
 
 // Фонарь
 export default class style {

--- a/www/js/block_style/pane.js
+++ b/www/js/block_style/pane.js
@@ -1,4 +1,4 @@
-import {DIRECTION, MULTIPLY, QUAD_FLAGS, ROTATE} from '../helpers.js';
+import {DIRECTION, IndexedColor, QUAD_FLAGS, ROTATE} from '../helpers.js';
 import {BLOCK} from "../blocks.js";
 
 // Панель
@@ -19,7 +19,7 @@ export default class style {
 
         const material = block.material;
         let flags = 0;
-        let lm = MULTIPLY.COLOR.WHITE;
+        let lm = IndexedColor.WHITE;
         const cardinal_direction = block.getCardinalDirection();
 
         let DIRECTION_BACK          = DIRECTION.BACK;
@@ -38,6 +38,8 @@ export default class style {
             lm.b = anim_frames;
             flags |= QUAD_FLAGS.FLAG_ANIMATED;
         }
+
+        let pp = IndexedColor.packLm(lm);
 
         // F R B L
         switch(cardinal_direction) {
@@ -86,42 +88,42 @@ export default class style {
         if(con_w) no_draw_center_sides.push(ROTATE.W);
         if(con_e) no_draw_center_sides.push(ROTATE.E);
 
-        push_part(vertices, tex, x + .5, bottom, z + .5, w, w, 1, no_draw_center_sides, lm, flags);
+        push_part(vertices, tex, x + .5, bottom, z + .5, w, w, 1, no_draw_center_sides, pp, flags);
 
         // South
         if(con_s) {
             let ndcs = [];
             if(neighbours.SOUTH.id == block.id) ndcs.push(ROTATE.S);
             if(neighbours.NORTH.id == block.id) ndcs.push(ROTATE.N);
-            push_part(vertices, tex, x + .5, bottom, z + connect_u/2, connect_v, connect_u, h, ndcs, lm, flags);
+            push_part(vertices, tex, x + .5, bottom, z + connect_u/2, connect_v, connect_u, h, ndcs, pp, flags);
         }
         // North
         if(con_n) {
             let ndcs = [];
             if(neighbours.SOUTH.id == block.id) ndcs.push(ROTATE.S);
             if(neighbours.NORTH.id == block.id) ndcs.push(ROTATE.N);
-            push_part(vertices, tex, x + .5, bottom, z + 1 - connect_u/2, connect_v, connect_u, h, ndcs, lm, flags);
+            push_part(vertices, tex, x + .5, bottom, z + 1 - connect_u/2, connect_v, connect_u, h, ndcs, pp, flags);
         }
         // West
         if(con_w) {
             let ndcs = [];
             if(neighbours.WEST.id == block.id) ndcs.push(ROTATE.W);
             if(neighbours.EAST.id == block.id) ndcs.push(ROTATE.E);
-            push_part(vertices, tex, x + connect_u/2, bottom, z + .5, connect_u, connect_v, h, ndcs, lm, flags);
+            push_part(vertices, tex, x + connect_u/2, bottom, z + .5, connect_u, connect_v, h, ndcs, pp, flags);
         }
         // East
         if(con_e) {
             let ndcs = [];
             if(neighbours.WEST.id == block.id) ndcs.push(ROTATE.W);
             if(neighbours.EAST.id == block.id) ndcs.push(ROTATE.E);
-            push_part(vertices, tex, x + 1 - connect_u/2, bottom, z + .5, connect_u, connect_v, h, ndcs, lm, flags);
+            push_part(vertices, tex, x + 1 - connect_u/2, bottom, z + .5, connect_u, connect_v, h, ndcs, pp, flags);
         }
 
     }
 
 }
 
-function push_part(vertices, c, x, y, z, xs, zs, h, no_draw_center_sides, lm, flags) {
+function push_part(vertices, c, x, y, z, xs, zs, h, no_draw_center_sides, pp, flags) {
 
     let sideFlags   = 0;
     let upFlags     = 0;
@@ -131,20 +133,20 @@ function push_part(vertices, c, x, y, z, xs, zs, h, no_draw_center_sides, lm, fl
         xs, 0, 0,
         0, zs, 0,
         c[0], c[1], c[2] * xs, c[3] * zs,
-        lm.r, lm.g, lm.b, flags | upFlags);
+        pp, flags | upFlags);
     // BOTTOM
     vertices.push(x, z, y,
         xs, 0, 0,
         0, -zs, 0,
         c[0], c[1], c[2] * xs, c[3] * zs,
-        lm.r, lm.g, lm.b, flags);
+        pp, flags);
     // SOUTH
     if(!no_draw_center_sides || no_draw_center_sides.indexOf(ROTATE.S) < 0) {
         vertices.push(x, z - zs/2, y + h/2,
             xs, 0, 0,
             0, 0, h,
             c[0], c[1], c[2]*xs, -c[3]*h,
-            lm.r, lm.g, lm.b, flags | sideFlags);
+            pp, flags | sideFlags);
     }
     // NORTH
     if(!no_draw_center_sides || no_draw_center_sides.indexOf(ROTATE.N) < 0) {
@@ -152,7 +154,7 @@ function push_part(vertices, c, x, y, z, xs, zs, h, no_draw_center_sides, lm, fl
             xs, 0, 0,
             0, 0, -h,
             c[0], c[1], -c[2]*xs, c[3]*h,
-            lm.r, lm.g, lm.b, flags | sideFlags);
+            pp, flags | sideFlags);
     }
     // WEST
     if(!no_draw_center_sides || no_draw_center_sides.indexOf(ROTATE.W) < 0) {
@@ -160,7 +162,7 @@ function push_part(vertices, c, x, y, z, xs, zs, h, no_draw_center_sides, lm, fl
             0, zs, 0,
             0, 0, -h,
             c[0], c[1], -c[2]*zs, c[3]*h,
-            lm.r, lm.g, lm.b, flags | sideFlags);
+            pp, flags | sideFlags);
     }
     // EAST
     if(!no_draw_center_sides || no_draw_center_sides.indexOf(ROTATE.E) < 0) {
@@ -168,6 +170,6 @@ function push_part(vertices, c, x, y, z, xs, zs, h, no_draw_center_sides, lm, fl
             0, zs, 0,
             0, 0, h,
             c[0], c[1], c[2]*zs, -c[3]*h,
-            lm.r, lm.g, lm.b, flags | sideFlags);
+            pp, flags | sideFlags);
     }
 }

--- a/www/js/block_style/plane.js
+++ b/www/js/block_style/plane.js
@@ -1,29 +1,30 @@
 import { pushSym } from "../core/CubeSym.js";
+import {IndexedColor} from "../helpers.js";
 
 /**
- * 
- * @param {*} vertices 
+ *
+ * @param {*} vertices
  * @param {*} x Start position X
  * @param {*} y Start position Y
  * @param {*} z Start position Z
- * @param {*} c 
- * @param {*} lm 
- * @param {*} x_dir 
- * @param {*} rot 
- * @param {*} xp 
- * @param {*} yp 
- * @param {*} zp 
- * @param {*} flags 
- * @param {*} sym 
+ * @param {*} c
+ * @param {*} lm
+ * @param {*} x_dir
+ * @param {*} rot
+ * @param {*} xp
+ * @param {*} yp
+ * @param {*} zp
+ * @param {*} flags
+ * @param {*} sym
  * @param {*} dx
  * @param {*} dy
  * @param {*} dz
  */
  export function pushPlanedGeom (
     vertices,
-    x, y, z, 
-    c, 
-    lm,
+    x, y, z,
+    c,
+    pp,
     x_dir, rot,
     xp, yp, zp,
     flags,
@@ -34,7 +35,7 @@ import { pushSym } from "../core/CubeSym.js";
     [z, y]   = [y, z];
     [zp, yp] = [yp, zp];
     [dz, dy] = [dy, dz];
-    
+
     xp          = xp ? xp : 1;
     yp          = yp ? yp : 1;
     zp          = zp ? zp : 1;
@@ -59,7 +60,7 @@ import { pushSym } from "../core/CubeSym.js";
                     xp, yp, 0,
                     0, 0, -zp,
                     c[0], c[1], c[2], c[3],
-                    lm.r, lm.g, lm.b, flags);
+                    pp, flags);
             }
             pushSym(vertices, sym,
                 x, y, z,
@@ -67,7 +68,7 @@ import { pushSym } from "../core/CubeSym.js";
                 -xp, yp, 0,
                 0, 0, -zp,
                 c[0], c[1], -c[2], c[3],
-                lm.r, lm.g, lm.b, flags);
+                pp, flags);
         } else {
             if(!ignore_back_side) {
                 pushSym(vertices, sym,
@@ -76,7 +77,7 @@ import { pushSym } from "../core/CubeSym.js";
                     xp, 0, 0,
                     0, 0, -zp,
                     c[0], c[1], c[2], c[3],
-                    lm.r, lm.g, lm.b, flags);
+                    pp, flags);
             }
             pushSym(vertices, sym,
                 x, y, z,
@@ -84,7 +85,7 @@ import { pushSym } from "../core/CubeSym.js";
                 -xp, 0, 0,
                 0, 0, -zp,
                 c[0], c[1], -c[2], c[3],
-                lm.r, lm.g, lm.b, flags);
+                pp, flags);
         }
     } else {
         if(rot) {
@@ -95,7 +96,7 @@ import { pushSym } from "../core/CubeSym.js";
                     -xp, -yp, 0,
                     0, 0, -zp,
                     c[0], c[1], c[2], c[3],
-                    lm.r, lm.g, lm.b, flags);
+                    pp, flags);
             }
             pushSym(vertices, sym,
                 x, y, z,
@@ -103,7 +104,7 @@ import { pushSym } from "../core/CubeSym.js";
                 xp, -yp, 0,
                 0, 0, -zp,
                 c[0], c[1], -c[2], c[3],
-                lm.r, lm.g, lm.b, flags);
+                pp, flags);
         } else {
             if(!ignore_back_side) {
                 pushSym(vertices, sym,
@@ -112,7 +113,7 @@ import { pushSym } from "../core/CubeSym.js";
                     0, yp, 0,
                     0, 0, -zp,
                     c[0], c[1], c[2], c[3],
-                    lm.r, lm.g, lm.b, flags);
+                    pp, flags);
             }
             pushSym(vertices, sym,
                 x, y, z,
@@ -120,7 +121,7 @@ import { pushSym } from "../core/CubeSym.js";
                 0, -yp, 0,
                 0, 0, -zp,
                 c[0], c[1], -c[2], c[3],
-                lm.r, lm.g, lm.b, flags);
+                pp, flags);
         }
     }
 
@@ -128,9 +129,9 @@ import { pushSym } from "../core/CubeSym.js";
 
 export function pushPlanedGeomCorrect (
     vertices,
-    x, y, z, 
-    c, 
-    lm,
+    x, y, z,
+    c,
+    pp,
     x_dir, rot,
     xp, yp, zp,
     flags,
@@ -140,7 +141,7 @@ export function pushPlanedGeomCorrect (
     [z, y]   = [y, z];
     [zp, yp] = [yp, zp];
     [dz, dy] = [dy, dz];
-    
+
     xp          = xp ? xp : 1;
     yp          = yp ? yp : 1;
     zp          = zp ? zp : 1;
@@ -164,14 +165,14 @@ export function pushPlanedGeomCorrect (
                 xp, yp, 0,
                 0, 0, -zp,
                 c[0], c[1], c[2], c[3],
-                lm.r, lm.g, lm.b, flags);
+                pp, flags);
             pushSym(vertices, sym,
                 x, y, z,
                 dx, dy, dz,
                 -xp, yp, 0,
                 0, 0, -zp,
                 c[0], c[1], -c[2], c[3],
-                lm.r, lm.g, lm.b, flags);
+                pp, flags);
         } else {
             pushSym(vertices, sym,
                 x, y, z,
@@ -179,14 +180,14 @@ export function pushPlanedGeomCorrect (
                 xp, 0, 0,
                 0, 0, -zp,
                 c[0], c[1], c[2], c[3],
-                lm.r, lm.g, lm.b, flags);
+                pp, flags);
             pushSym(vertices, sym,
                 x, y, z,
                 dx, dy, dz,
                 -xp, 0, 0,
                 0, 0, -zp,
                 c[0], c[1], -c[2], c[3],
-                lm.r, lm.g, lm.b, flags);
+                pp, flags);
         }
     } else {
         if(rot) {
@@ -196,14 +197,14 @@ export function pushPlanedGeomCorrect (
                 -xp, -yp, 0,
                 0, 0, -zp,
                 c[0], c[1], c[2], c[3],
-                lm.r, lm.g, lm.b, flags);
+                pp, flags);
             pushSym(vertices, sym,
                 x, y, z,
                 dx, dy, dz,
                 xp, -yp, 0,
                 0, 0, -zp,
                 c[0], c[1], -c[2], c[3],
-                lm.r, lm.g, lm.b, flags);
+                pp, flags);
         } else {
             pushSym(vertices, sym,
                 x, y, z,
@@ -211,14 +212,14 @@ export function pushPlanedGeomCorrect (
                 0, yp, 0,
                 0, 0, -zp,
                 c[0], c[1], c[2], c[3],
-                lm.r, lm.g, lm.b, flags);
+                pp, flags);
             pushSym(vertices, sym,
                 x, y, z,
                 dx, dy, dz,
                 0, -yp, 0,
                 0, 0, -zp,
                 c[0], c[1], -c[2], c[3],
-                lm.r, lm.g, lm.b, flags);
+                pp, flags);
         }
     }
 
@@ -238,7 +239,7 @@ export default class style {
         return pushPlanedGeom(
             vertices,
             x, y, z,
-            c, lm,
+            c, IndexedColor.packLm(lm),
             x_dir, rot,
             xp, yp, zp,
             flags, 0, 0, 0, 0,

--- a/www/js/block_style/planting.js
+++ b/www/js/block_style/planting.js
@@ -1,4 +1,4 @@
-import {MULTIPLY, DIRECTION, QUAD_FLAGS, Color, Vector, calcRotateMatrix} from '../helpers.js';
+import {IndexedColor, DIRECTION, QUAD_FLAGS, Color, Vector, calcRotateMatrix} from '../helpers.js';
 import {CHUNK_SIZE_X, CHUNK_SIZE_Z} from "../chunk_const.js";
 import {BLOCK} from "../blocks.js";
 import {impl as alea} from "../../vendors/alea.js";
@@ -103,7 +103,7 @@ export default class style {
         let dx = 0, dy = 0, dz = 0;
         let flag = QUAD_FLAGS.NO_AO | QUAD_FLAGS.NORMAL_UP;
 
-        style.lm.set(MULTIPLY.COLOR.WHITE);
+        style.lm.set(IndexedColor.WHITE);
         style.lm.b = BLOCK.getAnimations(material, 'up');
         if(style.lm.b > 1) {
             flag |= QUAD_FLAGS.FLAG_ANIMATED;
@@ -163,7 +163,7 @@ export default class style {
                 texture = BLOCK.calcMaterialTexture(material, DIRECTION.DOWN, null, null, block);
             }
         }
-        
+
         // Melon seeds
         if (material.name == "MELON_SEEDS") {
             if (block.extra_data.complete) {
@@ -171,16 +171,16 @@ export default class style {
                 texture = BLOCK.calcMaterialTexture(material, DIRECTION.DOWN, null, null, block);
                 planes = MELON_ATTACHED_PLANES;
                 switch (block.rotate.y) {
-                    case DIRECTION.NORTH: 
+                    case DIRECTION.NORTH:
                         planes[0].rot[1] = Math.PI;
                     break;
-                    case DIRECTION.WEST: 
+                    case DIRECTION.WEST:
                         planes[0].rot[1] = Math.PI * 3 / 2;
                     break;
-                    case DIRECTION.EAST: 
+                    case DIRECTION.EAST:
                         planes[0].rot[1] = Math.PI / 2;
                     break;
-                    default: 
+                    default:
                         planes[0].rot[1] = 0;
                     break;
                 }
@@ -189,7 +189,7 @@ export default class style {
                 texture = BLOCK.calcMaterialTexture(material, DIRECTION.UP, null, null, block);
             }
         }
-        
+
         for(let i = 0; i < planes.length; i++) {
             const plane = planes[i];
             // fill object

--- a/www/js/block_style/rails.js
+++ b/www/js/block_style/rails.js
@@ -1,11 +1,11 @@
-import { MULTIPLY, DIRECTION } from '../helpers.js';
+import { IndexedColor, DIRECTION } from '../helpers.js';
 import { BLOCK } from "../blocks.js";
 import { AABB } from '../core/AABB.js';
 import { RailShape } from '../block_type/rail_shape.js';
 
 // Рельсы
 export default class style {
-    
+
     static getRegInfo() {
         return {
             styles: ['rails'],
@@ -27,15 +27,15 @@ export default class style {
             return [aabb];
         }
     }
-    
+
     static func(block, vertices, chunk, x, y, z, neighbours, biome, dirt_color, unknown, matrix = null, pivot = null, force_tex) {
 
         if(typeof block == 'undefined') {
             return;
         }
-        
+
         const texture = block.material.texture;
-        
+
         //Рисуем блок
         switch(block.extra_data.shape) {
             case RailShape.NORTH_SOUTH: {
@@ -87,12 +87,12 @@ export default class style {
 }
 
 function plate(vertices, c, x, y, z, rot = 0, dir = 0, back = false) {
-    
-    const lm = MULTIPLY.COLOR.WHITE;
+
+    const pp = IndexedColor.WHITE.packed;
     const flags = 0;
-    
+
     const h = (dir == DIRECTION.UP || dir == DIRECTION.DOWN) ? 0.5 : 0.02;
-    
+
     let d = 0;
     if (dir == DIRECTION.UP) {
         d = -1;
@@ -102,20 +102,20 @@ function plate(vertices, c, x, y, z, rot = 0, dir = 0, back = false) {
 
     switch(rot) {
         case DIRECTION.SOUTH: {
-            vertices.push( x + 0.5, z + 0.5, y + h, 1, 0, 0, 0, 1, d, c[0], c[1], c[2], c[3], lm.r, lm.g, lm.b, flags);
+            vertices.push( x + 0.5, z + 0.5, y + h, 1, 0, 0, 0, 1, d, c[0], c[1], c[2], c[3], pp, flags);
             break;
         }
         case DIRECTION.EAST: {
-            vertices.push( x + 0.5, z + 0.5, y + h, 0, 1, 0, -1, 0, d, c[0], c[1], c[2], c[3], lm.r, lm.g, lm.b, flags);
+            vertices.push( x + 0.5, z + 0.5, y + h, 0, 1, 0, -1, 0, d, c[0], c[1], c[2], c[3], pp, flags);
             break;
         }
         case DIRECTION.WEST: {
-            vertices.push( x + 0.5, z + 0.5, y + h, 0, -1, 0, 1, 0, d, c[0], c[1], c[2], c[3], lm.r, lm.g, lm.b, flags);
+            vertices.push( x + 0.5, z + 0.5, y + h, 0, -1, 0, 1, 0, d, c[0], c[1], c[2], c[3], pp, flags);
             break;
         }
         default: {
-            vertices.push( x + 0.5, z + 0.5, y + h, -1, 0, 0, 0, -1, d, c[0], c[1], c[2], c[3], lm.r, lm.g, lm.b, flags);
+            vertices.push( x + 0.5, z + 0.5, y + h, -1, 0, 0, 0, -1, d, c[0], c[1], c[2], c[3], pp, flags);
         }
     }
-  
+
 }

--- a/www/js/block_style/redstone.js
+++ b/www/js/block_style/redstone.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import {Color, DIRECTION, QUAD_FLAGS, TX_CNT} from '../helpers.js';
+import {Color, DIRECTION, IndexedColor, QUAD_FLAGS, TX_CNT} from '../helpers.js';
 import {impl as alea} from "../../vendors/alea.js";
 import {BLOCK} from "../blocks.js";
 import {CHUNK_SIZE_X, CHUNK_SIZE_Z} from "../chunk_const.js";
@@ -26,8 +26,7 @@ export function pushTransformed(
     ux, uz, uy,
     vx, vz, vy,
     c0, c1, c2, c3,
-    r, g, b,
-    flags
+    pp, flags
 ) {
     pivot = pivot || defaultPivot;
     cx += pivot[0];
@@ -51,7 +50,7 @@ export function pushTransformed(
         vx * mat[6] + vy * mat[7] + vz * mat[8],
         vx * mat[3] + vy * mat[4] + vz * mat[5],
 
-        c0, c1, c2, c3, r, g, b, flags
+        c0, c1, c2, c3, pp, flags
     );
 }
 
@@ -91,6 +90,7 @@ export default class style {
         // Texture color multiplier
         // @todo from extra_data.signal
         const lm                = new Color(25.5 / tx_cnt, (31.5 + 1 / 16) / tx_cnt, 0, 0);
+        const pp                = IndexedColor.packLm(lm);
         const posworld          = block.posworld;
 
         const upper_neighbours_connect = {
@@ -140,7 +140,7 @@ export default class style {
                 1, 0, 0,
                 0, 1, 0,
                 ...c_line,
-                lm.r, lm.g, lm.b, flags);
+                pp, flags);
         }
 
         function drawSouth(x, y, z) {
@@ -152,7 +152,7 @@ export default class style {
                 1, 0, 0,
                 0, .5, 0,
                 c_line[0] - .25/16/32, c_line[1], c_line[2], c_line[3]/2,
-                lm.r, lm.g, lm.b, flags);
+                pp, flags);
         }
 
         function drawNorth(x, y, z) {
@@ -164,7 +164,7 @@ export default class style {
                 1, 0, 0,
                 0, .5, 0,
                 c_line[0] + .25/16/32, c_line[1], c_line[2], c_line[3]/2,
-                lm.r, lm.g, lm.b, flags);
+                pp, flags);
         }
 
         function drawX(x, y, z) {
@@ -176,7 +176,7 @@ export default class style {
                 .5, .5, 0,
                 ...top_vectors,
                 ...c_line,
-                lm.r, lm.g, lm.b, flags);
+                pp, flags);
         }
 
         function drawWest(x, y, z) {
@@ -188,7 +188,7 @@ export default class style {
                 .5, .5, 0,
                 ...top_vectors,
                 c_line[0] - .25/16/32, c_line[1], c_line[2], c_line[3]/2,
-                lm.r, lm.g, lm.b, flags);
+                pp, flags);
         }
 
         function drawEast(x, y, z) {
@@ -200,7 +200,7 @@ export default class style {
                 0.5, 0.5, 0,
                 ...top_vectors,
                 c_line[0] + .25/16/32, c_line[1], c_line[2], c_line[3]/2,
-                lm.r, lm.g, lm.b, flags);
+                pp, flags);
         }
 
         // 1.1
@@ -241,7 +241,7 @@ export default class style {
                 1, 0, 0,
                 0, 1, 0,
                 ...c_center,
-                lm.r, lm.g, lm.b, flags);
+                pp, flags);
         }
 
         // 2. Draw connects in upper neighbours
@@ -263,6 +263,7 @@ export default class style {
         // South
         if(upper_neighbours_connect.south) {
             let animations_south = 1;
+            let pp2 = IndexedColor.packArg(lm.r, lm.g, animations_south);
             pushTransformed(
                 vertices, matrix, pivot,
                 x, z + 1/500, y,
@@ -270,12 +271,13 @@ export default class style {
                 1, 0, 0,
                 0, 0, H,
                 c_line[0], c_line[1], c_line[2], -c_line[3],
-                lm.r, lm.g, animations_south, flags);
+                pp2, flags);
         }
 
         // North
         if(upper_neighbours_connect.north) {
             let animations_north = 1;
+            let pp2 = IndexedColor.packArg(lm.r, lm.g, animations_north);
             pushTransformed(
                 vertices, matrix, pivot,
                 x, z - 1/500, y,
@@ -283,12 +285,13 @@ export default class style {
                 1, 0, 0,
                 0, 0, -H,
                 c_line[0], c_line[1], -c_line[2], c_line[3],
-                lm.r, lm.g, animations_north, flags);
+                pp2, flags);
         }
 
         // West
         if(upper_neighbours_connect.west) {
             let animations_west = 1;
+            let pp2 = IndexedColor.packArg(lm.r, lm.g, animations_west);
             pushTransformed(
                 vertices, matrix, pivot,
                 x + 1/500, z, y,
@@ -296,12 +299,13 @@ export default class style {
                 0, 1, 0,
                 0, 0, -H,
                 c_line[0], c_line[1], -c_line[2], c_line[3],
-                lm.r, lm.g, animations_west, flags);
+                pp2, flags);
         }
 
         // East
         if(upper_neighbours_connect.east) {
             let animations_east = 1;
+            let pp2 = IndexedColor.packArg(lm.r, lm.g, animations_east);
             pushTransformed(
                 vertices, matrix, pivot,
                 x - 1/500, z, y,
@@ -309,7 +313,7 @@ export default class style {
                 0, 1, 0,
                 0, 0, H,
                 c_line[0], c_line[1], c_line[2], -c_line[3],
-                lm.r, lm.g, animations_east, flags);
+                pp2, flags);
         }
 
     }

--- a/www/js/block_style/slope.js
+++ b/www/js/block_style/slope.js
@@ -1,4 +1,4 @@
-import { MULTIPLY, DIRECTION, QUAD_FLAGS, Vector } from '../helpers.js';
+import { IndexedColor, DIRECTION, QUAD_FLAGS, Vector } from '../helpers.js';
 import { BLOCK } from "../blocks.js";
 import { AABB, AABBSideParams, PLANES, pushAABB } from '../core/AABB.js';
 import { TBlock } from '../typed_blocks3.js';
@@ -43,7 +43,7 @@ export default class style {
         const c                 = BLOCK.calcTexture(texture, DIRECTION.NORTH);
         const c_up              = BLOCK.calcTexture(texture, DIRECTION.UP);
         const c_down            = BLOCK.calcTexture(texture, DIRECTION.DOWN);
-        const lm                = MULTIPLY.COLOR.WHITE;
+        const lm                = IndexedColor.WHITE;
         const cd                = block.getCardinalDirection();
         const on_ceil           = style.isOnCeil(block);
         const anim_frames       = 0;

--- a/www/js/block_style/text.js
+++ b/www/js/block_style/text.js
@@ -3,19 +3,19 @@ import {AABB, AABBSideParams, pushAABB} from '../core/AABB.js';
 /**
  * @typedef {object} CharUV
  * @property {number} width - width
- * @property {number} height - height 
+ * @property {number} height - height
  * @property {number} xadvance
  * @property {number} yoffset
  * @property {number} x - x
  * @property {number} y - y
  * @property {string} char - char
- * 
+ *
  */
 
 /**
  * @typedef {object} Char
  * @property {number} width - normalised width
- * @property {number} height - normalised height 
+ * @property {number} height - normalised height
  * @property {number} xn - normalised x
  * @property {number} yn - normalised y
  * @property {number} shift_x - normalised shift x
@@ -50,7 +50,7 @@ export default class style {
         matrix,
         center,
         alignCenter = false,
-        color = [1, 1, 1]
+        color = [255, 255, 255]
     }) {
         const aabbc = style._aabbc;
         const totalHeight = baseHeight * lines;
@@ -108,14 +108,14 @@ export default class style {
             cursorX++;
 
             aabbc.translate(
-                0, 
+                0,
                 - aabbc.height + aabb.height,
                 0
             );
 
             if (alignCenter) {
                 aabbc.translate(
-                    -(maxX * refScale - aabb.width) * 0.5, 
+                    -(maxX * refScale - aabb.width) * 0.5,
                     (maxY * refScale - aabb.height) * 0.5,
                     0
                 );
@@ -163,10 +163,10 @@ export default class style {
         const chars = block.extra_data.chars;
 
         const args = {
-            aabb, 
-            chars, 
-            vertices, 
-            lines: LINES + 1, 
+            aabb,
+            chars,
+            vertices,
+            lines: LINES + 1,
             baseHeight: BASE_HEIGHT,
             center,
             matrix,

--- a/www/js/block_style/thin.js
+++ b/www/js/block_style/thin.js
@@ -1,4 +1,4 @@
-import {DIRECTION, MULTIPLY, NORMALS, QUAD_FLAGS, ROTATE} from '../helpers.js';
+import {DIRECTION, IndexedColor, NORMALS, QUAD_FLAGS, ROTATE} from '../helpers.js';
 import {BLOCK} from "../blocks.js";
 import { CubeSym } from '../core/CubeSym.js';
 
@@ -23,7 +23,7 @@ export default class style {
         const material  = block.material;
         let texture     = material.texture;
         let bH          = 1.0;
-        let lm          = MULTIPLY.COLOR.WHITE;
+        let lm          = IndexedColor.WHITE;
         let c           = BLOCK.calcTexture(texture, DIRECTION.FORWARD);
         let flags       = 0;
 
@@ -33,6 +33,7 @@ export default class style {
             lm.b = anim_frames;
             flags |= QUAD_FLAGS.FLAG_ANIMATED;
         }
+        let pp = IndexedColor.packLm(lm);
 
         switch(cardinal_direction) {
             case CubeSym.ROT_Z:
@@ -43,7 +44,7 @@ export default class style {
                     1, 0, 0,
                     0, 0, bH,
                     c[0], c[1], c[2], -c[3],
-                    lm.r, lm.g, lm.b, flags);
+                    pp, flags);
                 break;
             }
             case CubeSym.ROT_X:
@@ -55,7 +56,7 @@ export default class style {
                     0, 1, 0,
                     0, 0, -bH,
                     c[0], c[1], -c[2], c[3],
-                    lm.r, lm.g, lm.b, flags);
+                    pp, flags);
                 break;
             }
         }

--- a/www/js/block_style/trapdoor.js
+++ b/www/js/block_style/trapdoor.js
@@ -1,5 +1,5 @@
-import {DIRECTION, MULTIPLY, ROTATE, TX_CNT, Vector} from '../helpers.js';
-import {CubeSym, pushSym} from '../core/CubeSym.js';
+import {DIRECTION, IndexedColor, ROTATE, TX_CNT, Vector} from '../helpers.js';
+import {pushSym} from '../core/CubeSym.js';
 import {BLOCK} from "../blocks.js";
 
 // Люк
@@ -16,12 +16,6 @@ export default class style {
 
         if(!block || typeof block == 'undefined' || block.id == BLOCK.AIR.id) {
             return;
-        }
-
-        // Texture color multiplier
-        let lm = MULTIPLY.COLOR.WHITE;
-        if(block.id == BLOCK.GRASS_BLOCK.id) {
-            lm = dirt_color; // MULTIPLY.COLOR.GRASS;
         }
 
         let DIRECTION_UP            = DIRECTION.UP;
@@ -122,7 +116,7 @@ export default class style {
 //
 function push_part(vertices, cardinal_direction, cx, cy, cz, x, y, z, xs, zs, ys, tex_up_down, tex_front, tex_side, opened, on_ceil) {
 
-    let lm              = MULTIPLY.COLOR.WHITE;
+    let pp              = IndexedColor.WHITE.packed;
     let flags           = 0;
     let sideFlags       = 0;
     let upFlags         = 0;
@@ -155,40 +149,40 @@ function push_part(vertices, cardinal_direction, cx, cy, cz, x, y, z, xs, zs, ys
         x, z, y + ys,
         ...top_rotate,
         tex_up_down[0], tex_up_down[1], tex_up_down[2], tex_up_down[3],
-        lm.r, lm.g, lm.b, flags | upFlags);
+        pp, flags | upFlags);
     // BOTTOM
     pushSym(vertices, cardinal_direction,
         cx, cz, cy,
         x, z, y,
         ...bottom_rotate,
         tex_up_down[0], tex_up_down[1], tex_up_down[2], tex_up_down[3],
-        lm.r, lm.g, lm.b, flags);
+        pp, flags);
     // SOUTH
     pushSym(vertices, cardinal_direction,
         cx, cz, cy,
         x, z - zs/2, y + ys/2,
         ...south_rotate,
         tex_front[0], tex_front[1], tex_front[2], -tex_front[3],
-        lm.r, lm.g, lm.b, flags | sideFlags);
+        pp, flags | sideFlags);
     // NORTH
     pushSym(vertices, cardinal_direction,
         cx, cz, cy,
         x, z + zs/2, y + ys/2,
         ...north_rotate,
         tex_front[0], tex_front[1], -tex_front[2], tex_front[3],
-        lm.r, lm.g, lm.b, flags | sideFlags);
+        pp, flags | sideFlags);
     // WEST
     pushSym(vertices, cardinal_direction,
         cx, cz, cy,
         x - xs/2, z, y + ys/2,
         ...west_rotate,
         tex_side[0], tex_side[1], tex_side[2], -tex_side[3],
-        lm.r, lm.g, lm.b, flags | sideFlags);
+        pp, flags | sideFlags);
     // EAST
     pushSym(vertices, cardinal_direction,
         cx, cz, cy,
         x + xs/2, z, y + ys/2,
         ...east_rotate,
         tex_side[0], tex_side[1], tex_side[2], -tex_side[3],
-        lm.r, lm.g, lm.b, flags | sideFlags);
+        pp, flags | sideFlags);
 }

--- a/www/js/block_style/triangle.js
+++ b/www/js/block_style/triangle.js
@@ -1,4 +1,4 @@
-import {DIRECTION, MULTIPLY, NORMALS, ROTATE, TX_CNT} from '../helpers.js';
+import {DIRECTION, NORMALS, IndexedColor, ROTATE, TX_CNT, Vector} from '../helpers.js';
 import { default as push_plane_style } from './plane.js';
 import {BLOCK} from "../blocks.js";
 
@@ -19,7 +19,7 @@ export default class style {
         const half          = 0.5 / TX_CNT;
         let poses           = [];
         let texture         = block.material.texture;
-        let lm              = MULTIPLY.COLOR.WHITE;
+        let pp              = IndexedColor.WHITE.packed;
 
         block.transparent   = true;
 
@@ -49,20 +49,20 @@ export default class style {
         // Нижний слэб
 
         // South - стенка 1
-        push_plane(vertices, x, yb, z - 0.5, c_half_bottom, lm, true, false, null, .5, null);
+        push_plane(vertices, x, yb, z - 0.5, c_half_bottom, pp, true, false, null, .5, null);
 
         // North - стенка 2
-        push_plane(vertices, x, yb, z + 0.5, c_half_bottom, lm, true, false, null, .5, null);
+        push_plane(vertices, x, yb, z + 0.5, c_half_bottom, pp, true, false, null, .5, null);
 
         // East - стенка 3
-        push_plane(vertices, x + 0.5, yb, z, c_half_bottom, lm, false, false, null, 1, null);
+        push_plane(vertices, x + 0.5, yb, z, c_half_bottom, pp, false, false, null, 1, null);
 
         // West - стенка 4
         vertices.push(x + 1/2, y + 1/2, z + 1/2,
             1, 1, 0,
             0, 0, -1,
             ...c,
-            lm.r, lm.g, lm.b, 0);
+            pp, 0);
 
         c = BLOCK.calcTexture(texture, DIRECTION.DOWN);
 
@@ -72,7 +72,7 @@ export default class style {
             1, 0, 0,
             0, -1, 0,
             c[0], c[1], c[2], -c[3],
-            lm.r, lm.g, lm.b, 0);
+            pp, 0);
 
         // поверхность нижней ступени
         const bH = 1;

--- a/www/js/block_style/wall.js
+++ b/www/js/block_style/wall.js
@@ -1,4 +1,4 @@
-import {DIRECTION, MULTIPLY, Vector} from '../helpers.js';
+import {DIRECTION, IndexedColor, Vector} from '../helpers.js';
 import {BLOCK} from "../blocks.js";
 import { TBlock } from '../typed_blocks3.js';
 
@@ -93,7 +93,7 @@ export default class style {
 }
 
 function push_part(vertices, c, x, y, z, xs, zs, h) {
-    let lm          = MULTIPLY.COLOR.WHITE;
+    let pp          = IndexedColor.WHITE.packed;
     let flags       = 0;
     let sideFlags   = 0;
     let upFlags     = 0;
@@ -102,35 +102,35 @@ function push_part(vertices, c, x, y, z, xs, zs, h) {
         xs, 0, 0,
         0, zs, 0,
         c[0], c[1], c[2] * xs, c[3] * zs,
-        lm.r, lm.g, lm.b, flags | upFlags);
+        pp, flags | upFlags);
     // BOTTOM
     vertices.push(x, z, y,
         xs, 0, 0,
         0, -zs, 0,
         c[0], c[1], c[2] * xs, c[3] * zs,
-        lm.r, lm.g, lm.b, flags);
+        pp, flags);
     // SOUTH
     vertices.push(x, z - zs/2, y + h/2,
         xs, 0, 0,
         0, 0, h,
         c[0], c[1], c[2]*xs, -c[3]*h,
-        lm.r, lm.g, lm.b, flags | sideFlags);
+        pp, flags | sideFlags);
     // NORTH
     vertices.push(x, z + zs/2, y + h/2,
         xs, 0, 0,
         0, 0, -h,
         c[0], c[1], -c[2]*xs, c[3]*h,
-        lm.r, lm.g, lm.b, flags | sideFlags);
+        pp, flags | sideFlags);
     // WEST
     vertices.push(x - xs/2, z, y + h/2,
         0, zs, 0,
         0, 0, -h,
         c[0], c[1], -c[2]*zs, c[3]*h,
-        lm.r, lm.g, lm.b, flags | sideFlags);
+        pp, flags | sideFlags);
     // EAST
     vertices.push(x + xs/2, z, y + h/2,
         0, zs, 0,
         0, 0, h,
         c[0], c[1], c[2]*zs, -c[3]*h,
-        lm.r, lm.g, lm.b, flags | sideFlags);
+        pp, flags | sideFlags);
 }

--- a/www/js/core/AABB.js
+++ b/www/js/core/AABB.js
@@ -1,5 +1,5 @@
 import {CubeSym} from "./CubeSym.js";
-import {MULTIPLY, Vector} from '../helpers.js';
+import {IndexedColor, Vector} from '../helpers.js';
 import glMatrix from "../../vendors/gl-matrix-3.3.min.js"
 
 const {mat3, mat4, vec3}      = glMatrix;
@@ -320,8 +320,7 @@ export function pushTransformed(
     ux, uz, uy,
     vx, vz, vy,
     c0, c1, c2, c3,
-    r, g, b,
-    flags
+    pp, flags
 ) {
     pivot = pivot || defaultPivot;
     cx += pivot[0];
@@ -361,7 +360,7 @@ export function pushTransformed(
         vx * mat[6] + vy * mat[7] + vz * mat[8],
         vx * mat[3] + vy * mat[4] + vz * mat[5],
 
-        c0, c1, c2, c3, r, g, b, flags
+        c0, c1, c2, c3, pp, flags
     );
 }
 
@@ -386,7 +385,7 @@ export function pushAABB(vertices, aabb, pivot = null, matrix = null, sides, cen
     center = center || defalutCenter;
     pivot  = pivot  || defaultPivot;
 
-    const lm_default      = MULTIPLY.COLOR.WHITE;
+    const lm_default      = IndexedColor.WHITE;
     const globalFlags     = 0;
     const x               = center.x;
     const y               = center.y;
@@ -460,10 +459,7 @@ export function pushAABB(vertices, aabb, pivot = null, matrix = null, sides, cen
             uv[0], uv[1],
             // UV size
             uvSize0, uvSize1,
-            // tint location or RG
-            r, g,
-            // animation or b color
-            b,
+            IndexedColor.packArg(r, g, b),
             // flags
             globalFlags | flag
         );

--- a/www/js/core/CubeSym.js
+++ b/www/js/core/CubeSym.js
@@ -192,8 +192,7 @@ export function pushSym(
         x0, z0, y0,
         ux, uz, uy, vx, vz, vy,
         c0, c1, c2, c3,
-        r, g, b,
-        flags
+        pp, flags
     ) {
     const mat = CubeSym.matrices[sym];
     vertices.push(
@@ -209,6 +208,6 @@ export function pushSym(
         vx * mat[6] + vy * mat[7] + vz * mat[8],
         vx * mat[3] + vy * mat[4] + vz * mat[5],
 
-        c0, c1, c2, c3, r, g, b, flags
+        c0, c1, c2, c3, pp, flags
     );
 }

--- a/www/js/geom/TerrainGeometry16.js
+++ b/www/js/geom/TerrainGeometry16.js
@@ -23,20 +23,20 @@ class QuadAttr {
         this.axisY = buffer.subarray(offset + 6, offset + 9);
         this.uvCenter = buffer.subarray(offset + 9, offset + 11);
         this.uvSize = buffer.subarray(offset + 11, offset + 13);
-        this.color = buffer.subarray(offset + 13, offset + 16);
-        this.flags = buffer.subarray(offset + 16, offset + 17);
+        this.color = buffer.subarray(offset + 13, offset + 14);
+        this.flags = buffer.subarray(offset + 14, offset + 15);
 
         return this;
     }
 }
 
-export class GeometryTerrain18 {
+export class GeometryTerrain16 {
     constructor(vertices) {
         // убрал, для уменьшения объема оперативной памяти
         // this.vertices = vertices;
         this.updateID = 0;
         this.uploadID = -1;
-        this.strideFloats = GeometryTerrain18.strideFloats;
+        this.strideFloats = GeometryTerrain16.strideFloats;
         this.stride = this.strideFloats * 4;
 
         /**
@@ -95,9 +95,9 @@ export class GeometryTerrain18 {
         gl.vertexAttribPointer(attribs.a_axisY, 3, gl.FLOAT, false, stride, 6 * 4);
         gl.vertexAttribPointer(attribs.a_uvCenter, 2, gl.FLOAT, false, stride, 9 * 4);
         gl.vertexAttribPointer(attribs.a_uvSize, 2, gl.FLOAT, false, stride, 11 * 4);
-        gl.vertexAttribPointer(attribs.a_color, 3, gl.FLOAT, false, stride, 13 * 4);
-        gl.vertexAttribPointer(attribs.a_flags, 1, gl.FLOAT, false, stride, 16 * 4);
-        gl.vertexAttribPointer(attribs.a_chunkId, 1, gl.FLOAT, false, stride, 17 * 4);
+        gl.vertexAttribIPointer(attribs.a_color, 1, gl.UNSIGNED_INT, stride, 13 * 4);
+        gl.vertexAttribPointer(attribs.a_flags, 1, gl.FLOAT, false, stride, 14 * 4);
+        gl.vertexAttribPointer(attribs.a_chunkId, 1, gl.FLOAT, false, stride, 15 * 4);
 
         gl.vertexAttribDivisor(attribs.a_position, 1);
         gl.vertexAttribDivisor(attribs.a_axisX, 1);
@@ -177,11 +177,11 @@ export class GeometryTerrain18 {
      * @returns
      */
     rawQuad(index = 0, target = new QuadAttr()) {
-        return target.set(this.buffer, index * GeometryTerrain18.strideFloats);
+        return target.set(this.buffer, index * GeometryTerrain16.strideFloats);
     }
 
     * rawQuads(start = 0, count = this.size) {
-        return GeometryTerrain18.iterateBuffer(this.buffer, start, count);
+        return GeometryTerrain16.iterateBuffer(this.buffer, start, count);
     }
 
     destroy() {
@@ -228,5 +228,5 @@ export class GeometryTerrain18 {
         return out.set(buffer, offset)
     }
 
-    static strideFloats = 18;
+    static strideFloats = 16;
 }

--- a/www/js/helpers.js
+++ b/www/js/helpers.js
@@ -1046,12 +1046,38 @@ export class Vector {
 
 export class Vec3 extends Vector {}
 
-export let MULTIPLY = {
-    COLOR: {
-        WHITE: new Color(816 / 1024, 1008 / 1024, 0, 0),
-        GRASS: new Color(900 / 1024, 965 / 1024, 0, 0)
+export class IndexedColor {
+    static packLm(lm) {
+        return IndexedColor.packArg(lm.r, lm.g, lm.b);
     }
-};
+
+    static WHITE = null;
+    static GRASS = null;
+
+    static packArg(palU, palV, palMode) {
+        palU = Math.round(palU);
+        palV = Math.round(palV);
+        return (palMode << 20) | (palV << 10) | (palU << 0);
+    }
+
+    constructor(r, g, b) {
+        this.r = r | 0;
+        this.g = g | 0;
+        this.b = b | 0;
+        this.packed = IndexedColor.packArg(this.r, this.g, this.b);
+    }
+
+    clone() {
+        return new IndexedColor(this.r, this.g, this.b);
+    }
+
+    pack() {
+        return this.packed = IndexedColor.packArg(this.r, this.g, this.b);
+    }
+}
+
+IndexedColor.WHITE = new IndexedColor(816, 1008, 0);
+IndexedColor.GRASS = new IndexedColor(900, 965, 0, 0);
 
 export let QUAD_FLAGS = {}
     QUAD_FLAGS.NORMAL_UP = 1 << 0;
@@ -1127,7 +1153,7 @@ export class Helpers {
         return Helpers.cache;
     }
 
-    // 
+    //
     angleTo(pos, target) {
         let angle = Math.atan2(target.x - pos.x, target.z - pos.z);
         return (angle > 0) ? angle : angle + 2 * Math.PI;

--- a/www/js/hud.js
+++ b/www/js/hud.js
@@ -1,7 +1,7 @@
 import {WindowManager} from "../tools/gui/wm.js";
 import {MainMenu} from "./window/index.js";
 import {FPSCounter} from "./fps.js";
-import GeometryTerrain from "./geometry_terrain.js";
+import {GeometryTerrain16} from "./geom/TerrainGeometry16.js";
 import {Helpers} from './helpers.js';
 import {Resources} from "./resources.js";
 import {Particles_Effects} from "./particles/effects.js";
@@ -314,7 +314,7 @@ export class HUD {
             //
             let quads_length_total = world.chunkManager.vertices_length_total;
             this.text += '\nQuads: ' + Math.round(Qubatch.render.renderBackend.stat.drawquads) + ' / ' + quads_length_total // .toLocaleString(undefined, {minimumFractionDigits: 0}) +
-                + ' / ' + Math.round(quads_length_total * GeometryTerrain.strideFloats * 4 / 1024 / 1024) + 'Mb';
+                + ' / ' + Math.round(quads_length_total * GeometryTerrain16.strideFloats * 4 / 1024 / 1024) + 'Mb';
             this.text += '\nLightmap: ' + Math.round(world.chunkManager.lightmap_count)
                 + ' / ' + Math.round(world.chunkManager.lightmap_bytes / 1024 / 1024) + 'Mb';
             //

--- a/www/js/light/Basic05GeometryPool.js
+++ b/www/js/light/Basic05GeometryPool.js
@@ -4,7 +4,7 @@ import {GeometryPool} from "./GeometryPool.js";
 
 export class Basic05GeometryPool extends GeometryPool {
     constructor(context, {
-        pageSize = 227,
+        pageSize = 256,
         pageCount = 1000,
         growCoeff = 1.5
     }) {

--- a/www/js/light/GeometryPool.js
+++ b/www/js/light/GeometryPool.js
@@ -1,4 +1,4 @@
-import { GeometryTerrain18 } from "../geom/TerrainGeometry18.js";
+import { GeometryTerrain16 } from "../geom/TerrainGeometry16.js";
 
 export class GeometryPool {
     constructor(context) {
@@ -28,7 +28,7 @@ export class TrivialGeometryPool extends GeometryPool {
             lastBuffer.destroy();
         }
 
-        const vert = new Float32Array(vertices[0] * GeometryTerrain18.strideFloats);
+        const vert = new Float32Array(vertices[0] * GeometryTerrain16.strideFloats);
         let pos = 0;
         for (let i=1; i < vertices.length; i++) {
             const floatBuffer = new Float32Array(vertices[i]);
@@ -36,6 +36,6 @@ export class TrivialGeometryPool extends GeometryPool {
             pos += floatBuffer.length;
         }
 
-        return new GeometryTerrain18(vert);
+        return new GeometryTerrain16(vert);
     }
 }

--- a/www/js/light/TerrainMultiGeometry.js
+++ b/www/js/light/TerrainMultiGeometry.js
@@ -1,7 +1,7 @@
 import GeometryTerrain from "../geometry_terrain.js";
 
 export class TerrainMultiGeometry {
-    static strideFloats = 18;
+    static strideFloats = 16;
     static sortAss = (a, b) => {
         return a - b;
     };
@@ -58,9 +58,9 @@ export class TerrainMultiGeometry {
         gl.vertexAttribPointer(attribs.a_axisY, 3, gl.FLOAT, false, stride, 6 * 4);
         gl.vertexAttribPointer(attribs.a_uvCenter, 2, gl.FLOAT, false, stride, 9 * 4);
         gl.vertexAttribPointer(attribs.a_uvSize, 2, gl.FLOAT, false, stride, 11 * 4);
-        gl.vertexAttribPointer(attribs.a_color, 3, gl.FLOAT, false, stride, 13 * 4);
-        gl.vertexAttribPointer(attribs.a_flags, 1, gl.FLOAT, false, stride, 16 * 4);
-        gl.vertexAttribPointer(attribs.a_chunkId, 1, gl.FLOAT, false, stride, 17 * 4);
+        gl.vertexAttribIPointer(attribs.a_color, 1, gl.UNSIGNED_INT, stride, 13 * 4);
+        gl.vertexAttribPointer(attribs.a_flags, 1, gl.FLOAT, false, stride, 14 * 4);
+        gl.vertexAttribPointer(attribs.a_chunkId, 1, gl.FLOAT, false, stride, 15 * 4);
 
         gl.vertexAttribDivisor(attribs.a_position, 1);
         gl.vertexAttribDivisor(attribs.a_axisX, 1);
@@ -158,50 +158,6 @@ export class TerrainMultiGeometry {
             }
         }
         updates.length = j;
-    }
-
-    /**
-     * both offsets are in quads
-     * @param dstOffset
-     * @param list
-     * @param srcOffset
-     * @param chunkId
-     */
-    update17(dstOffset, list, srcOffset, srcQuads, chunkId) {
-        if (srcQuads === 0) {
-            return;
-        }
-        dstOffset *= this.strideFloats;
-        srcOffset *= 17;
-        let j = dstOffset, k = srcOffset;
-        const {data} = this;
-        for (let i = 0; i < srcQuads; i++) {
-            data[j++] = list[k++];
-            data[j++] = list[k++];
-            data[j++] = list[k++];
-            data[j++] = list[k++];
-            data[j++] = list[k++];
-
-            data[j++] = list[k++];
-            data[j++] = list[k++];
-            data[j++] = list[k++];
-            data[j++] = list[k++];
-            data[j++] = list[k++];
-
-            data[j++] = list[k++];
-            data[j++] = list[k++];
-            data[j++] = list[k++];
-            data[j++] = list[k++];
-            data[j++] = list[k++];
-
-            data[j++] = list[k++];
-            data[j++] = list[k++];
-
-            data[j++] = chunkId;
-        }
-
-        this.updates.push(dstOffset, j);
-        this.updateID++;
     }
 
     updatePage(dstOffset, floatBuffer) {

--- a/www/js/light/TerrainSubGeometry.js
+++ b/www/js/light/TerrainSubGeometry.js
@@ -9,25 +9,6 @@ export class TerrainSubGeometry {
         this.sizePages = sizePages;
     }
 
-    setData17(vertices, chunkId) {
-        this.sizeQuads = this.size = vertices.length / 17;
-        const {baseGeometry, pages, glOffsets, glCounts} = this;
-        const {pageSize} = this.pool;
-        glOffsets.length = glCounts.length = 0;
-        for (let i = 0; i < this.sizePages; i++) {
-            const start = i * pageSize;
-            const finish = Math.min(this.sizeQuads, (i + 1) * pageSize);
-            if (i > 0 && pages[i] === pages[i - 1] + 1) {
-                glCounts[glCounts.length - 1] += finish - start;
-            } else {
-                glOffsets.push(pages[i] * pageSize);
-                glCounts.push(finish - start);
-            }
-            baseGeometry.update17(pages[i] * pageSize,
-                vertices, start, finish - start, chunkId);
-        }
-    }
-
     setDataPages(vertices) {
         const {baseGeometry, pages, glOffsets, glCounts} = this;
         const {pageSize} = this.pool;

--- a/www/js/light/Worker05GeometryPool.js
+++ b/www/js/light/Worker05GeometryPool.js
@@ -2,9 +2,9 @@ import {GeometryPool} from "./GeometryPool.js";
 
 export class Worker05GeometryPool extends GeometryPool {
     constructor(context, {
-        pageSize = 227,
+        pageSize = 256,
         pageCount = 100,
-        instanceSize = 18,
+        instanceSize = 16,
     }) {
         super(context)
 
@@ -40,10 +40,11 @@ export class Worker05GeometryPool extends GeometryPool {
 }
 
 export class Worker05GeometryPage {
-    constructor({sizeQuads = 227, instanceSize = 18}) {
+    constructor({sizeQuads = 256, instanceSize = 16}) {
         this.sizeQuads = sizeQuads;
         this.instanceSize = instanceSize;
         this.data = new Float32Array(sizeQuads * instanceSize);
+        this.uint32Data = new Uint32Array(this.data.buffer);
         this.clear();
     }
 
@@ -73,13 +74,13 @@ export class Worker05SubGeometry {
     }
 
     push(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
-         arg10, arg11, arg12, arg13, arg14, arg15, arg16) {
+         arg10, arg11, arg12, arg13, arg14/*, arg15*/) {
         if (!this.lastPage || this.lastPage.filled === this.lastPage.sizeQuads) {
             this.pages.push(this.lastPage = this.pool.allocPage());
         }
 
-        const data = this.lastPage.data;
-        const ind = (this.lastPage.filled++) * 18;
+        const data = this.lastPage.data, uint32Data = this.lastPage.uint32Data;
+        const ind = (this.lastPage.filled++) * 16;
         this.filled++;
 
         data[ind] = arg0;
@@ -95,11 +96,12 @@ export class Worker05SubGeometry {
         data[ind + 10] = arg10;
         data[ind + 11] = arg11;
         data[ind + 12] = arg12;
-        data[ind + 13] = arg13;
+        uint32Data[ind + 13] = arg13;
         data[ind + 14] = arg14;
-        data[ind + 15] = arg15;
-        data[ind + 16] = arg16;
-        data[ind + 17] = this.chunkDataId;
+        data[ind + 15] = this.chunkDataId;
+        // if (arg15) {
+        //     console.log('old build logic');
+        // }
     }
 
     // offsets are in instances

--- a/www/js/mesh/group.js
+++ b/www/js/mesh/group.js
@@ -1,4 +1,4 @@
-import {Color, QUAD_FLAGS, Vector, VectorCollector} from '../helpers.js';
+import {IndexedColor, QUAD_FLAGS, Vector, VectorCollector} from '../helpers.js';
 import GeometryTerrain from "../geometry_terrain.js";
 import {BLOCK} from "../blocks.js";
 import { AABB } from '../core/AABB.js';
@@ -122,7 +122,7 @@ export class MeshGroup {
      * @param {bool} force_inventory_style
      */
     buildVertices(tx, ty, tz, force_inventory_style, matrix, pivot) {
-        const dirt_color = new Color(850 / 1024, 930 / 1024, 0, 0);
+        const dirt_color = new IndexedColor(850, 930, 0, 0);
         const biome = {
             code:       'GRASSLAND',
             color:      '#98a136'
@@ -179,7 +179,7 @@ export class MeshGroup {
 
         // Create draw buffers
         this.meshes.forEach((mesh, _, map) => {
-            mesh.buffer = new GeometryTerrain(new Float32Array(mesh.vertices));
+            mesh.buffer = new GeometryTerrain(mesh.vertices);
             mesh.buffer.changeFlags(QUAD_FLAGS.NO_AO, 'or');
         });
 

--- a/www/js/particles/block_destroy.js
+++ b/www/js/particles/block_destroy.js
@@ -1,4 +1,4 @@
-import { Color, DIRECTION, getChunkAddr, MULTIPLY, QUAD_FLAGS, Vector } from '../helpers.js';
+import { Color, DIRECTION, getChunkAddr, IndexedColor, QUAD_FLAGS, Vector } from '../helpers.js';
 import { CHUNK_SIZE_X } from "../chunk_const.js";
 import GeometryTerrain from "../geometry_terrain.js";
 import { default as push_plane_style } from '../block_style/plane.js';
@@ -32,7 +32,7 @@ export default class Particles_Block_Destroy extends Particles_Base {
         }
 
         let flags       = QUAD_FLAGS.NO_AO;
-        let lm          = MULTIPLY.COLOR.WHITE;
+        let lm          = IndexedColor.WHITE;
 
         if(typeof this.texture != 'function' && typeof this.texture != 'object' && !(this.texture instanceof Array)) {
             this.life = 0;
@@ -118,10 +118,10 @@ export default class Particles_Block_Destroy extends Particles_Base {
             p.dz = p.z / d * p.speed;
         }
 
-        this.vertices = new Float32Array(this.vertices);
-
         // we should save start values
-        this.buffer = new GeometryTerrain(this.vertices.slice());
+        this.buffer = new GeometryTerrain(this.vertices);
+        // geom terrain converts vertices array to float32/uint32data combo, now we can take it
+        this.vertices = this.buffer.data.slice();
 
     }
 

--- a/www/js/particles/rain.js
+++ b/www/js/particles/rain.js
@@ -1,4 +1,4 @@
-import { Color, getChunkAddr, QUAD_FLAGS, Vector, VectorCollector } from '../helpers.js';
+import { IndexedColor, getChunkAddr, QUAD_FLAGS, Vector, VectorCollector } from '../helpers.js';
 import GeometryTerrain from "../geometry_terrain.js";
 import { BLEND_MODES } from '../renders/BaseRenderer.js';
 import { AABB, AABBSideParams, pushAABB } from '../core/AABB.js';
@@ -10,7 +10,9 @@ import { CHUNK_SIZE_X, CHUNK_SIZE_Y, CHUNK_SIZE_Z } from '../chunk_const.js';
 const {mat4} = glMatrix;
 
 const TARGET_TEXTURES   = [.5, .5, 1, .25];
-const RAIN_SPEED        = 2 / 1000;
+const RAIN_SPEED        = 1023; // 1023 pixels per second scroll . 1024 too much for our IndexedColor
+const SNOW_SPEED        = 42;
+const SNOW_SPEED_X      = 16;
 const RAIN_RAD          = 8;
 const RAIN_HEIGHT       = 14;
 
@@ -113,9 +115,9 @@ export default class Particles_Rain {
     }
 
     prepare() {
-        
+
         const player = Qubatch.player;
-        
+
         if(!this.#_player_block_pos.equal(player.blockPos)) {
             this.#_player_block_pos.copyFrom(player.blockPos);
             this.#_version++;
@@ -210,7 +212,7 @@ export default class Particles_Rain {
         const snow = this.type == 'snow';
 
         const vertices  = [];
-        const lm        = new Color((snow ? RAIN_SPEED / 16 : 0), -RAIN_SPEED / (snow ? 24 : 1), 0);
+        const lm        = new IndexedColor((snow ? SNOW_SPEED_X : 0), snow ? SNOW_SPEED : RAIN_SPEED, 0);
         const sideFlags = QUAD_FLAGS.FLAG_TEXTURE_SCROLL | QUAD_FLAGS.NO_CAN_TAKE_LIGHT;
         const pivot     = null;
         const matrix    = null;

--- a/www/js/pickat.js
+++ b/www/js/pickat.js
@@ -241,7 +241,7 @@ export class PickAt {
     // createTargetBuffer...
     createTargetBuffer(pos, c) {
         let vertices    = [];
-        let lm          = new Color(0, 0, 0);
+        let pp = 0;
         let flags       = 0, sideFlags = 0, upFlags = 0;
         let block       = this.world.chunkManager.getBlock(pos.x, pos.y, pos.z);
         let shapes      = BLOCK.getShapes(pos, block, this.world, false, true);
@@ -265,37 +265,37 @@ export class PickAt {
                 xw, 0, 0,
                 0, zw, 0,
                 c[0], c[1], c[2], c[3],
-                lm.r, lm.g, lm.b, flags | upFlags);
+                pp, flags | upFlags);
             // Bottom
             vertices.push(x, z, y_bottom,
                 xw, 0, 0,
                 0, -zw, 0,
                 c[0], c[1], c[2], c[3],
-                lm.r, lm.g, lm.b, flags);
+                pp, flags);
             // South | Forward | z++ (XZY)
             vertices.push(x, z - zw/2, y_bottom + yw/2,
                 xw, 0, 0,
                 0, 0, yw,
                 c[0], c[1], c[2], -c[3],
-                lm.r, lm.g, lm.b, flags | sideFlags);
+                pp, flags | sideFlags);
             // North | Back | z--
             vertices.push(x, z + zw/2, y_bottom + yw/2,
                 xw, 0, 0,
                 0, 0, -yw,
                 c[0], c[1], -c[2], c[3],
-                lm.r, lm.g, lm.b, flags | sideFlags);
+                pp, flags | sideFlags);
             // West | Left | x--
             vertices.push(x - xw/2, z, y_bottom + yw/2,
                 0, zw, 0,
                 0, 0, -yw,
                 c[0], c[1], -c[2], c[3],
-                lm.r, lm.g, lm.b, flags | sideFlags);
+                pp, flags | sideFlags);
             // East | Right | x++
             vertices.push(x + xw/2, z, y_bottom + yw/2,
                 0, zw, 0,
                 0, 0, yw,
                 c[0], c[1], -c[2], c[3],
-                lm.r, lm.g, lm.b, flags | sideFlags);
+                pp, flags | sideFlags);
         }
         return new GeometryTerrain(vertices);
     }

--- a/www/js/render.js
+++ b/www/js/render.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import {Mth, CAMERA_MODE, DIRECTION, Helpers, Vector, Color, calcRotateMatrix, fromMat3, QUAD_FLAGS} from "./helpers.js";
+import {Mth, CAMERA_MODE, DIRECTION, IndexedColor, Helpers, Vector, Color, calcRotateMatrix, fromMat3, QUAD_FLAGS} from "./helpers.js";
 import {CHUNK_SIZE_X, INVENTORY_ICON_COUNT_PER_TEX, INVENTORY_ICON_TEX_HEIGHT, INVENTORY_ICON_TEX_WIDTH} from "./chunk_const.js";
 import rendererProvider from "./renders/rendererProvider.js";
 import {FrustumProxy} from "./frustum.js";
@@ -893,6 +893,7 @@ export class Renderer {
     // createShadowBuffer...
     createShadowVertices(vertices, shapes, pos, c) {
         let lm          = new Color(0, 0, (performance.now() / 1000) % 1);
+        let pp          = IndexedColor.WHITE;
         let flags       = QUAD_FLAGS.QUAD_FLAG_OPACITY, sideFlags = 0, upFlags = 0;
         for (let i = 0; i < shapes.length; i++) {
             const shape = shapes[i];
@@ -925,7 +926,7 @@ export class Renderer {
                     xw, 0, 0,
                     0, zw, 0,
                     -c0, -c1, c[2], c[3],
-                    lm.r, lm.g, lm.b, flags | upFlags);
+                    pp, flags | upFlags);
             }
         }
     }

--- a/www/js/terrain_generator/biomes.js
+++ b/www/js/terrain_generator/biomes.js
@@ -1,4 +1,4 @@
-import {Color} from '../helpers.js';
+import {Color, IndexedColor} from '../helpers.js';
 import {BLOCK} from "../blocks.js";
 
 const CACTUS_MIN_HEIGHT     = 2;
@@ -36,7 +36,7 @@ export class TREES {
 export class  BIOMES {
 
     static init() {
-    
+
         if(BIOMES.OCEAN) {
             return false;
         }
@@ -47,7 +47,7 @@ export class  BIOMES {
             block:      BLOCK.STILL_WATER.id,
             code:       'OCEAN',
             color:      '#017bbb',
-            dirt_color: new Color(900 / 1024, 880 / 1024, 0, 0),
+            dirt_color: new IndexedColor(900, 880, 0),
             title:      'ОКЕАН',
             max_height: 64,
             dirt_block: [BLOCK.SAND.id, BLOCK.GRAVEL.id, BLOCK.GRASS_BLOCK.id, BLOCK.CLAY.id],
@@ -61,12 +61,12 @@ export class  BIOMES {
                 list: []
             }
         };
-        
+
         BIOMES.RIVER = {
             block:      BLOCK.STILL_WATER.id,
             code:       'OCEAN',
             color:      '#017bbb',
-            dirt_color: new Color(900 / 1024, 880 / 1024, 0, 0),
+            dirt_color: new IndexedColor(900, 880, 0),
             title:      'ОКЕАН',
             max_height: 64,
             dirt_block: [BLOCK.SAND.id, BLOCK.GRAVEL.id, BLOCK.CLAY.id, BLOCK.GRASS_BLOCK.id],
@@ -80,12 +80,12 @@ export class  BIOMES {
                 list: []
             }
         };
-        
+
         BIOMES.BEACH = {
             block: BLOCK.SAND.id,
             code:       'BEACH',
             color:      '#ffdc7f',
-            dirt_color: new Color(770 / 1024, 990 / 1024, 0, 0),
+            dirt_color: new IndexedColor(770, 990, 0),
             title:      'ПЛЯЖ',
             max_height: 64,
             dirt_block: [BLOCK.SAND.id],
@@ -101,12 +101,12 @@ export class  BIOMES {
                 ]
             }
         };
-        
+
         BIOMES.TEMPERATE_DESERT = {
             block:      BLOCK.GRAVEL.id,
             code:       'TEMPERATE_DESERT',
             color:      '#f4a460',
-            dirt_color: new Color(840 / 1024, 980 / 1024, 0, 0),
+            dirt_color: new IndexedColor(840, 980, 0),
             title:      'УМЕРЕННАЯ ПУСТЫНЯ',
             dirt_block: [BLOCK.SAND.id],
             max_height: 6,
@@ -124,12 +124,12 @@ export class  BIOMES {
                 ]
             }
         };
-        
+
         BIOMES.JUNGLE = {
             block:      BLOCK.OAK_PLANKS.id,
             code:       'JUNGLE',
             color:      '#4eb41c',
-            dirt_color: new Color(800 / 1024, 825 / 1024, 0, 0),
+            dirt_color: new IndexedColor(800, 825, 0),
             title:      'ДЖУНГЛИ',
             max_height: 48,
             dirt_block: [BLOCK.GRASS_BLOCK.id, BLOCK.GRASS_BLOCK.id, BLOCK.DIRT.id],
@@ -157,12 +157,12 @@ export class  BIOMES {
                 ]
             }
         };
-        
+
         BIOMES.SUBTROPICAL_DESERT = {
             block:      BLOCK.OAK_PLANKS.id,
             code:       'SUBTROPICAL_DESERT',
             color:      '#c19a6b',
-            dirt_color: new Color(845 / 1024, 990 / 1024, 0, 0),
+            dirt_color: new IndexedColor(845, 990, 0),
             title:      'СУБТРОПИЧЕСКАЯ ПУСТЫНЯ',
             max_height: 6,
             dirt_block: [BLOCK.GRASS_BLOCK.id, BLOCK.GRASS_BLOCK.id, BLOCK.DIRT.id, BLOCK.PODZOL.id],
@@ -184,12 +184,12 @@ export class  BIOMES {
                 ]
             }
         };
-        
+
         BIOMES.SCORCHED = {
             block:      BLOCK.STONE.id,
             code:       'SCORCHED',
             color:      '#ff5500',
-            dirt_color: new Color(770 / 1024, 990 / 1024, 0, 0),
+            dirt_color: new IndexedColor(770, 990, 0),
             title:      'ОБОГРЕВАЮЩИЙ',
             max_height: 12,
             dirt_block: [BLOCK.SAND.id],
@@ -207,12 +207,12 @@ export class  BIOMES {
                 ]
             }
         };
-        
+
         BIOMES.BARE = {
             block: BLOCK.OAK_LOG.id,
             code:       'BARE',
             color:      '#CCCCCC',
-            dirt_color: new Color(960 / 1024, 950 / 1024, 0, 0),
+            dirt_color: new IndexedColor(960, 950, 0),
             title:      'ПУСТОШЬ',
             max_height: 64,
             dirt_block: [BLOCK.STONE.id],
@@ -220,12 +220,12 @@ export class  BIOMES {
             trees:      {},
             plants:     {frequency: 0}
         };
-        
+
         BIOMES.TUNDRA = {
             block: BLOCK.SPRUCE_LOG.id,
             code:       'TUNDRA',
             color:      '#74883c',
-            dirt_color: new Color(980 / 1024, 980 / 1024, 0, 0),
+            dirt_color: new IndexedColor(980, 980, 0),
             title:      'ТУНДРА',
             max_height: 48,
             dirt_block: [BLOCK.GRASS_BLOCK.id, BLOCK.PODZOL.id],
@@ -252,11 +252,11 @@ export class  BIOMES {
                 ]
             }
         };
-        
+
         BIOMES.TAIGA = {
             block: BLOCK.OAK_LOG.id,
             code:       'TAIGA',
-            dirt_color: new Color(1000 / 1024, 990 / 1024, 0, 0),
+            dirt_color: new IndexedColor(1000, 990, 0),
             color:      '#879b89',
             title:      'ТАЙГА',
             max_height: 12,
@@ -274,12 +274,12 @@ export class  BIOMES {
                 list: []
             }
         };
-        
+
         BIOMES.SNOW = {
             block:      BLOCK.POWDER_SNOW.id,
             code:       'SNOW',
             color:      '#f5f5ff',
-            dirt_color: new Color(1020 / 1024, 990 / 1024, 0, 0),
+            dirt_color: new IndexedColor(1020, 990, 0),
             title:      'СНЕГ',
             max_height: 35,
             dirt_block: [BLOCK.SNOW_DIRT.id],
@@ -296,12 +296,12 @@ export class  BIOMES {
                 list: []
             }
         };
-        
+
         BIOMES.SHRUBLAND = {
             block: BLOCK.DIAMOND_ORE.id,
             code:       'SHRUBLAND',
             color:      '#316033',
-            dirt_color: new Color(880 / 1024, 870 / 1024, 0, 0),
+            dirt_color: new IndexedColor(880, 870, 0),
             title:      'КУСТАРНИКИ',
             dirt_block: [BLOCK.GRASS_BLOCK.id],
             no_smooth:  false,
@@ -315,12 +315,12 @@ export class  BIOMES {
                 ]
             }
         };
-        
+
         BIOMES.GRASSLAND = {
             block:      BLOCK.GRASS_BLOCK.id,
             code:       'GRASSLAND',
             color:      '#98a136',
-            dirt_color: new Color(850 / 1024, 930 / 1024, 0, 0),
+            dirt_color: new IndexedColor(850, 930, 0),
             title:      'ТРАВЯНАЯ ЗЕМЛЯ',
             max_height: 18,
             dirt_block: [BLOCK.GRASS_BLOCK.id],
@@ -349,12 +349,12 @@ export class  BIOMES {
                 ]
             }
         };
-        
+
         BIOMES.TEMPERATE_DECIDUOUS_FOREST = {
             block: BLOCK.GLASS.id,
             code:       'TEMPERATE_DECIDUOUS_FOREST',
             color:      '#228b22',
-            dirt_color: new Color(800 / 1024, 880 / 1024, 0, 0),
+            dirt_color: new IndexedColor(800, 880, 0),
             title:      'УМЕРЕННЫЙ ЛИСТЫЙ ЛЕС',
             max_height: 48,
             dirt_block: [BLOCK.GRASS_BLOCK.id],
@@ -375,12 +375,12 @@ export class  BIOMES {
                 ]
             }
         };
-        
+
         BIOMES.TEMPERATE_RAIN_FOREST = {
             block: BLOCK.COBBLESTONE.id,
             code:       'TEMPERATE_RAIN_FOREST',
             color:      '#00755e',
-            dirt_color: new Color(900 / 1024, 880 / 1024, 0, 0),
+            dirt_color: new IndexedColor(900, 880, 0),
             title:      'УМЕРЕННЫЙ ДОЖДЬ ЛЕС',
             max_height: 15,
             dirt_block: [BLOCK.GRASS_BLOCK.id],
@@ -397,13 +397,13 @@ export class  BIOMES {
                 list: []
             }
         };
-        
+
         BIOMES.TROPICAL_SEASONAL_FOREST = {
             block:      BLOCK.BRICKS.id,
             code:       'TROPICAL_SEASONAL_FOREST',
             color:      '#008456',
-            dirt_color: new Color(900 / 1024, 900 / 1024, 0, 0),
-            // dirt_color: new Color(900 / 1024, 965 / 1024, 0, 0),
+            dirt_color: new IndexedColor(900, 900, 0),
+            // dirt_color: new IndexedColor(900, 965, 0),
             title:      'ТРОПИЧЕСКИЙ СЕЗОННЫЙ ЛЕС',
             max_height: 32,
             dirt_block: [BLOCK.GRASS_BLOCK.id],
@@ -423,12 +423,12 @@ export class  BIOMES {
                 ]
             }
         };
-        
+
         BIOMES.TROPICAL_RAIN_FOREST = {
             block:      BLOCK.GLOWSTONE.id,
             code:       'TROPICAL_RAIN_FOREST',
             color:      '#16994f',
-            dirt_color: new Color(860 / 1024, 910 / 1024, 0, 0),
+            dirt_color: new IndexedColor(860, 910, 0),
             title:      'ГРИБНОЙ',
             max_height: 64,
             dirt_block: [BLOCK.GRASS_BLOCK.id, BLOCK.GRASS_BLOCK.id, BLOCK.MYCELIUM.id, BLOCK.MOSS_BLOCK.id],
@@ -451,7 +451,7 @@ export class  BIOMES {
                 ]
             }
         };
-        
+
         for(let k in BIOMES) {
             const biome = BIOMES[k];
             biome.code = k;

--- a/www/js/terrain_generator/bottom_caves/index.js
+++ b/www/js/terrain_generator/bottom_caves/index.js
@@ -1,4 +1,4 @@
-import { Color, Vector } from '../../helpers.js';
+import { IndexedColor, Vector } from '../../helpers.js';
 import { Default_Terrain_Generator, Default_Terrain_Map, Default_Terrain_Map_Cell } from '../default.js';
 import { BLOCK } from '../../blocks.js';
 import { CHUNK_SIZE } from "../../chunk_const.js";
@@ -52,38 +52,38 @@ export default class Terrain_Generator extends Default_Terrain_Generator {
         let xyz_stone_density       = new Vector(0, 0, 0);
         let DENSITY_COEFF           = 1;
         let fill_count              = 0;
-    
+
         const { cx, cy, cz, cw, tblocks } = chunk;
         //
         const getBlock = (x, y, z) => {
             const index = cx * x + cy * y + cz * z + cw;
             return tblocks.id[index];
         };
-    
+
         //
         for(let x = 0; x < chunk.size.x; x++) {
-    
+
             for(let z = 0; z < chunk.size.z; z++) {
-    
+
                 let y_start                 = Infinity;
                 let stalactite_height       = 0;
                 let stalactite_can_start    = false;
                 let dripstone_allow         = true;
-    
+
                 for(let y = chunk.size.y - 1; y >= 0; y--) {
-    
+
                     xyz.set(x + chunk.coord.x, y + chunk.coord.y, z + chunk.coord.z);
-    
+
                     let density = (
                         noise3d(xyz.x / (100 * DENSITY_COEFF), xyz.y / (15 * DENSITY_COEFF), xyz.z / (100 * DENSITY_COEFF)) / 2 + .5 +
                         noise3d(xyz.x / (20 * DENSITY_COEFF), xyz.y / (20 * DENSITY_COEFF), xyz.z / (20 * DENSITY_COEFF)) / 2 + .5
                     ) / 2;
-    
+
                     if(xyz.y > -ABS_STONE) {
                         const dist = xyz.y / -ABS_STONE + .2;
                         density += dist;
                     }
-    
+
                     // air
                     if(density < 0.5) {
                         if(stalactite_can_start) {
@@ -136,11 +136,11 @@ export default class Terrain_Generator extends Default_Terrain_Generator {
                         }
                         continue;
                     }
-    
+
                     let stone_block_id = BLOCK.STONE.id;
                     xyz_stone_density.set(xyz.x + 100000, xyz.y + 100000, xyz.z + 100000);
                     let stone_density = noise3d(xyz_stone_density.x / 20, xyz_stone_density.z / 20, xyz_stone_density.y / 20) / 2 + .5;
-    
+
                     if(stone_density < .025) {
                         stone_block_id = BLOCK.GLOWSTONE.id;
                     } else {
@@ -169,20 +169,20 @@ export default class Terrain_Generator extends Default_Terrain_Generator {
                             }
                         }
                     }
-    
+
                     chunk.setBlockIndirect(x, y, z, stone_block_id);
-    
+
                     // reset stalactite
                     stalactite_can_start    = stone_block_id == BLOCK.DRIPSTONE_BLOCK.id;
                     y_start                 = Infinity;
                     stalactite_height       = 0;
-    
+
                     fill_count++;
-    
+
                 }
             }
         }
-    
+
         // Amethyst room
         if(fill_count > CHUNK_SIZE * .7) {
             let chance = aleaRandom.double();
@@ -249,10 +249,10 @@ export default class Terrain_Generator extends Default_Terrain_Generator {
                 }
             }
         }
-    
+
         if(generate_map) {
 
-            const cell = {dirt_color: new Color(850 / 1024, 930 / 1024, 0, 0), biome: new Default_Terrain_Map_Cell({
+            const cell = {dirt_color: new IndexedColor(850, 930, 0), biome: new Default_Terrain_Map_Cell({
                 code: 'Flat'
             })};
 

--- a/www/js/terrain_generator/city/index.js
+++ b/www/js/terrain_generator/city/index.js
@@ -1,4 +1,4 @@
-import {Color, Vector} from '../../helpers.js';
+import {IndexedColor, Vector} from '../../helpers.js';
 import {BLOCK} from '../../blocks.js';
 import {alea, Default_Terrain_Generator, Default_Terrain_Map, Default_Terrain_Map_Cell} from "../default.js";
 
@@ -263,7 +263,7 @@ export default class Terrain_Generator extends Default_Terrain_Generator {
             }
         }
 
-        const cell = {dirt_color: new Color(850 / 1024, 930 / 1024, 0, 0), biome: new Default_Terrain_Map_Cell({
+        const cell = {dirt_color: new IndexedColor(850, 930, 0), biome: new Default_Terrain_Map_Cell({
             code: 'City'
         })};
 

--- a/www/js/terrain_generator/city2/index.js
+++ b/www/js/terrain_generator/city2/index.js
@@ -1,4 +1,4 @@
-import {Color, Vector} from '../../helpers.js';
+import {IndexedColor, Vector} from '../../helpers.js';
 import {Vox_Loader} from "../../vox/loader.js";
 import {Vox_Mesh} from "../../vox/mesh.js";
 import { Default_Terrain_Generator, Default_Terrain_Map, Default_Terrain_Map_Cell } from '../default.js';
@@ -68,9 +68,9 @@ export default class Terrain_Generator extends Default_Terrain_Generator {
             166: BLOCK.CYAN_WOOL,
             174: BLOCK.BLUE_WOOL,
             234: BLOCK.POWDER_SNOW,
-        
+
             238: BLOCK.TEST,
-        
+
             // 97: BLOCK.OAK_PLANKS,
             // 121: BLOCK.STONE_BRICKS,
             // 122: BLOCK.SMOOTH_STONE,
@@ -139,7 +139,7 @@ export default class Terrain_Generator extends Default_Terrain_Generator {
 
         }
 
-        const cell = {dirt_color: new Color(850 / 1024, 930 / 1024, 0, 0), biome: new Default_Terrain_Map_Cell({
+        const cell = {dirt_color: new IndexedColor(850, 930, 0), biome: new Default_Terrain_Map_Cell({
             code: 'City2'
         })};
 

--- a/www/js/terrain_generator/default.js
+++ b/www/js/terrain_generator/default.js
@@ -69,7 +69,7 @@ export class Default_Terrain_Generator {
             }
         }
 
-        let cell = {biome: {dirt_color: new Color(980 / 1024, 980 / 1024, 0, 0), code: 'Flat'}};
+        let cell = {biome: {dirt_color: new Indexedcolor(980, 980, 0), code: 'Flat'}};
         let cells = Array(chunk.size.x).fill(null).map(el => Array(chunk.size.z).fill(cell));
 
         return {

--- a/www/js/terrain_generator/flat/index.js
+++ b/www/js/terrain_generator/flat/index.js
@@ -1,4 +1,4 @@
-import { Color } from '../../helpers.js';
+import { IndexedColor } from '../../helpers.js';
 import { Default_Terrain_Generator, Default_Terrain_Map, Default_Terrain_Map_Cell } from '../default.js';
 import { BLOCK } from '../../blocks.js';
 
@@ -37,7 +37,7 @@ export default class Terrain_Generator extends Default_Terrain_Generator {
             }
         }
 
-        const cell = {dirt_color: new Color(850 / 1024, 930 / 1024, 0, 0), biome: new Default_Terrain_Map_Cell({
+        const cell = {dirt_color: new IndexedColor(850, 930, 0), biome: new Default_Terrain_Map_Cell({
             code: 'Flat'
         })};
 

--- a/www/js/terrain_generator/flying_islands/index.js
+++ b/www/js/terrain_generator/flying_islands/index.js
@@ -1,4 +1,4 @@
-import { Color, Vector } from '../../helpers.js';
+import { IndexedColor, Vector } from '../../helpers.js';
 import { Default_Terrain_Map, Default_Terrain_Map_Cell } from '../default.js';
 import { BLOCK } from '../../blocks.js';
 import { noise, alea } from "../default.js";
@@ -22,7 +22,7 @@ export default class Terrain_Generator extends Demo_Map {
 
         //
         const generateMap = () => {
-            const cell = {dirt_color: new Color(850 / 1024, 930 / 1024, 0, 0), biome: new Default_Terrain_Map_Cell({
+            const cell = {dirt_color: new IndexedColor(850, 930, 0), biome: new Default_Terrain_Map_Cell({
                 code: 'Flat'
             })};
             return new Default_Terrain_Map(

--- a/www/js/terrain_generator/mine/index.js
+++ b/www/js/terrain_generator/mine/index.js
@@ -1,4 +1,4 @@
-import {Color, Vector, DIRECTION_BIT} from '../../helpers.js';
+import {IndexedColor, Vector, DIRECTION_BIT} from '../../helpers.js';
 import {DungeonGenerator} from '../dungeon.js';
 import { Default_Terrain_Generator } from '../default.js';
 import {BLOCK} from '../../blocks.js';
@@ -15,7 +15,7 @@ export default class MineGenerator2 extends Default_Terrain_Generator {
     }
 
     async init() {}
-    
+
     generate(chunk) {
         const aleaRandom = new alea(this.s + chunk.addr.toString());
         if(chunk.addr.y == 0) {
@@ -27,10 +27,10 @@ export default class MineGenerator2 extends Default_Terrain_Generator {
                 }
             }
         }
-        
+
         this.dungeon.add(chunk);
 
-        const cell = {dirt_color: new Color(850 / 1024, 930 / 1024, 0, 0), biome: {
+        const cell = {dirt_color: new IndexedColor(850, 930, 0), biome: {
             code: 'Flat'
         }};
 

--- a/www/js/terrain_generator/test_trees/index.js
+++ b/www/js/terrain_generator/test_trees/index.js
@@ -1,5 +1,5 @@
 import {CHUNK_SIZE_X, CHUNK_SIZE_Y, CHUNK_SIZE_Z} from "../../chunk_const.js";
-import {Color, Vector} from '../../helpers.js';
+import {IndexedColor, Vector} from '../../helpers.js';
 import { Default_Terrain_Generator, alea } from '../default.js';
 import {BLOCK} from '../../blocks.js';
 import {TREES} from '../../terrain_generator/biomes.js';
@@ -55,7 +55,7 @@ export default class Terrain_Generator extends Default_Terrain_Generator {
             );
         }
 
-        const cell = {dirt_color: new Color(850 / 1024, 930 / 1024, 0, 0), biome: {
+        const cell = {dirt_color: new IndexedColor(850, 930, 0), biome: {
             code: 'Flat'
         }};
 

--- a/www/resource_packs/base/shaders/webgl/fragment.glsl
+++ b/www/resource_packs/base/shaders/webgl/fragment.glsl
@@ -26,7 +26,7 @@ vec4 sampleAtlassTexture (vec4 mipData, vec2 texClamped, vec2 biomPos) {
     vec4 color = texture(u_texture, texc * mipData.zw + mipData.xy);
 
     if (v_color.a > 0.0) {
-        float mask_shift = v_color.b * 32.;
+        float mask_shift = v_color.b;
         vec4 color_mask = texture(u_texture, vec2(texc.x + u_blockSize * max(mask_shift, 1.), texc.y) * mipData.zw + mipData.xy);
         vec4 color_mult = texture(u_texture, biomPos);
         color.rgb += color_mask.rgb * color_mult.rgb;
@@ -63,8 +63,8 @@ void main() {
 
             float msdfSize = 100.0;
 
-            vec4 msdfColor = vec4(v_color.rgb, 1.0);
-            vec4 outlineColor = vec4(1.0 - v_color.rgb, 0.8);
+            vec4 msdfColor = vec4(v_color.rgb / 255.0, 1.0);
+            vec4 outlineColor = vec4(1.0 - v_color.rgb / 255.0, 0.8);
 
             float msdfFactor =  0.5 * length(fwidth(v_texcoord0) * msdfSize);
             float totalThreshold = threshold - outline;
@@ -89,7 +89,7 @@ void main() {
             // default texture fetch pipeline
 
             mipData = manual_mip(v_texcoord0, size);
-            biome = v_color.rg * (1. - 0.5 * step(0.5, u_mipmap));
+            biome = (v_color.rg / 1024.0) * (1. - 0.5 * step(0.5, u_mipmap));
             color = sampleAtlassTexture (mipData, texClamped, biome);
 
             if (v_animInterp > 0.0) {

--- a/www/resource_packs/base/shaders/webgl/vertex.glsl
+++ b/www/resource_packs/base/shaders/webgl/vertex.glsl
@@ -9,7 +9,9 @@
 void main() {
     #include<terrain_read_flags_vert>
 
-    v_color = vec4(a_color, 1.0);
+    v_color = vec4(float(a_color & uint(0x3ff)),
+        float((a_color >> 10) & uint(0x3ff)),
+        a_color >> 20, 1.0);
     vec2 uvCenter0 = a_uvCenter;
     vec2 uvCenter1 = a_uvCenter;
     v_animInterp = 0.0;
@@ -27,7 +29,8 @@ void main() {
     if(flagAnimated > 0) {
         // v_color.b contain number of animation frames
         float frames = v_color.b;
-        float t = ((u_time * v_color.b / 3.) / 1000.);
+        v_color.b = 1024.0; // no mask_shift for you, sorry
+        float t = ((u_time * frames / 3.) / 1000.);
         float i = floor(t);
         uvCenter0.y += mod(i, frames) / 32.;
         uvCenter1.y += mod(i + 1., frames) / 32.;
@@ -51,10 +54,13 @@ void main() {
     }
 
     // Scrolled textures
-    uvCenter0.x += float(flagScroll) * (u_time * v_color.r);
-    uvCenter1.x += float(flagScroll) * (u_time * v_color.r);
-    uvCenter0.y += float(flagScroll) * (u_time * v_color.g);
-    uvCenter1.y += float(flagScroll) * (u_time * v_color.g);
+    if (flagScroll > 0) {
+        vec2 sz = vec2(128.0, 512.0);
+        uvCenter0.x += u_time / 1000.0 * v_color.r / sz.x;
+        uvCenter1.x += u_time / 1000.0 * v_color.r / sz.x;
+        uvCenter0.y -= u_time / 1000.0 * v_color.g / sz.y;
+        uvCenter1.y -= u_time / 1000.0 * v_color.g / sz.y;
+    }
 
     //
     v_texcoord0 = uvCenter0 + a_uvSize * a_quad;

--- a/www/shaders/shader.blocks.glsl
+++ b/www/shaders/shader.blocks.glsl
@@ -89,7 +89,7 @@
     in vec3 a_axisY;
     in vec2 a_uvCenter;
     in vec2 a_uvSize;
-    in vec3 a_color;
+    in uint a_color;
     in float a_flags;
     in vec2 a_quad;
 


### PR DESCRIPTION
First refactoring to fix our overgrown rendering flags
Also, brings down quad geometry size from 18 to 16 floats/uint32

`npm run compile-texture-pack` is required.

Next steps will move palette out of main texture, and maybe merge with light palette to save space