### PR TITLE
Fix nibble crash due to chunk id hickup

### DIFF
--- a/www/js/worker-light/DirNibbleQueue.js
+++ b/www/js/worker-light/DirNibbleQueue.js
@@ -129,14 +129,15 @@ export class DirNibbleQueue {
                 continue;
             }
             if (chunk !== newChunk) {
-                if (!newChunk.nibbleDims) {
+                chunk = newChunk;
+                lightChunk = chunk.lightChunk;
+
+                if (!lightChunk.nibbleDims) {
                     // dayLight somehow goes under y<0 limit, where it shouldn't.
                     // probably chunk ID conflict
                     continue;
                 }
 
-                chunk = newChunk;
-                lightChunk = chunk.lightChunk;
                 uint8View = lightChunk.uint8View;
                 outerSize = lightChunk.outerSize;
                 strideBytes = lightChunk.strideBytes;

--- a/www/js/worker-light/DirNibbleQueue.js
+++ b/www/js/worker-light/DirNibbleQueue.js
@@ -129,6 +129,12 @@ export class DirNibbleQueue {
                 continue;
             }
             if (chunk !== newChunk) {
+                if (!newChunk.nibbleDims) {
+                    // dayLight somehow goes under y<0 limit, where it shouldn't.
+                    // probably chunk ID conflict
+                    continue;
+                }
+
                 chunk = newChunk;
                 lightChunk = chunk.lightChunk;
                 uint8View = lightChunk.uint8View;


### PR DESCRIPTION
subj. Sometimes new chunk id is same as  removed chunk id somewhere deep in the queue. In that case algo starts checking wrong place, but it shouldn't crash!