### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/node_server/plugins/worldedit/binary_schematic.ts
+++ b/node_server/plugins/worldedit/binary_schematic.ts
@@ -502,7 +502,7 @@ export class BinarySchematic {
                 readStingLength = readSignedVarInt
                 readArrayLength = readSignedVarInt
             }
-            // типы тэгов: https://minecraft.fandom.com/wiki/NBT_format#TAG_definition
+            // типы тэгов: https://minecraft.wiki/w/NBT_format#TAG_definition
             readers[1] = () => file_buffer.readInt8()
             readers[2] = () => file_buffer.readInt16()
             readers[3] = () => file_buffer.readInt32()

--- a/www/src/enchantments.ts
+++ b/www/src/enchantments.ts
@@ -32,7 +32,7 @@ export class Enchantments {
 
         ids are strings because it's the easist way to store them as keys of extra_data.enchantments.
 
-        The original list: https://minecraft.fandom.com/wiki/Anvil_mechanics#Combining_items
+        The original list: https://minecraft.wiki/w/Anvil_mechanics#Combining_items
     */
     static byId = {
         0: {

--- a/www/src/prismarine-physics/index.ts
+++ b/www/src/prismarine-physics/index.ts
@@ -121,7 +121,7 @@ export class Physics {
         maxUp: 0.5,
         friction: 0.4
     }
-    // Особые значения для лодки в воде. Не подогнано точно как в майне. См. https://minecraft.fandom.com/wiki/Boat#Speed
+    // Особые значения для лодки в воде. Не подогнано точно как в майне. См. https://minecraft.wiki/w/Boat#Speed
     private readonly boatLiquidAcceleration = 0.08
     private readonly boatLiquidInertia = 0.9
     // Особые значения для лодки на льду. Не подогнано точно как в майне.

--- a/www/src/prismarine-physics/using.ts
+++ b/www/src/prismarine-physics/using.ts
@@ -35,7 +35,7 @@ export type TPrismarineOptions = {
     /** If it's defined, the object floats, and this value is its height below the surface. */
     floatSubmergedHeight? : float
 
-    /** Если это определено, то применяется специальный режим вычсления скорости, см. https://minecraft.fandom.com/wiki/Boat#Speed */
+    /** Если это определено, то применяется специальный режим вычсления скорости, см. https://minecraft.wiki/w/Boat#Speed */
     useBoatSpeed        ? : boolean
 
     airborneInertia     ? : float // 0.91 in Minecraft (default), 0.546 in typical old bugged jumps


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki